### PR TITLE
feat: deprecating api-version query param in api calls

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -33,9 +33,14 @@ func (c *Client) DoCustomRequest(ctx context.Context, method, path, version stri
 
 // DoCustomRequestAndReturnRawResponse Executes a Custom Request and returns a APIResponse and the Raw HTTP Response
 func (c *Client) DoCustomRequestAndReturnRawResponse(ctx context.Context, method, path, version string, body interface{}, opts interface{}) (*http.Response, *APIResponse, error) {
+	// version is no longer used and is ignored.
+	return c.DoCustomRequestAndReturnRawResponseV5(ctx, method, path, body, opts)
+}
+
+func (c *Client) DoCustomRequestAndReturnRawResponseV5(ctx context.Context, method, path string, body interface{}, opts interface{}) (*http.Response, *APIResponse, error) {
 	firstTime := true
 start:
-	u, err := generateURL(*c.baseURL, path, version, opts)
+	u, err := generateURL(*c.baseURL, path, opts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Generating Path: %w", err)
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -169,17 +169,14 @@ func (c *Client) log(msg string, args ...interface{}) {
 	fmt.Printf("[go-passbolt] "+msg+"\n", args...)
 }
 
-func generateURL(base url.URL, p, version string, opt interface{}) (string, error) {
+func generateURL(base url.URL, p string, opt interface{}) (string, error) {
 	base.Path = path.Join(base.Path, p)
-
 	vs, err := query.Values(opt)
 	if err != nil {
 		return "", fmt.Errorf("Getting URL Query Values: %w", err)
 	}
-	if version != "" {
-		vs.Add("api-version", version)
-	}
 	base.RawQuery = vs.Encode()
+
 	return base.String(), nil
 }
 


### PR DESCRIPTION
This PR resolves #28 