### PR TITLE
Handle error for unsupported resource type

### DIFF
--- a/helper/errors.go
+++ b/helper/errors.go
@@ -1,0 +1,7 @@
+package helper
+
+import "errors"
+
+// ErrUnsupportedResourceType is returned when a resource has an unknown resource type slug
+// that cannot be decoded by the helper functions.
+var ErrUnsupportedResourceType = errors.New("unsupported resource type")

--- a/helper/metadata.go
+++ b/helper/metadata.go
@@ -82,7 +82,7 @@ func validateMetadata(rType *api.ResourceType, metadata string) error {
 		if string(definition) == "[]" || string(definition) == "\"[]\"" {
 			tmp, ok := api.ResourceSchemas[rType.Slug]
 			if !ok {
-				return fmt.Errorf("Server Does not have the Required json Schema and there is no fallback available for type: %v", rType.Slug)
+				return fmt.Errorf("%w: %v (no schema available)", ErrUnsupportedResourceType, rType.Slug)
 			}
 			definition = tmp
 		}

--- a/helper/resource_get.go
+++ b/helper/resource_get.go
@@ -197,7 +197,7 @@ func GetResourceFromDataWithOptions(c *api.Client, resource api.Resource, secret
 			uri = metadata.URIs[0]
 		}
 	default:
-		return "", "", "", "", "", "", fmt.Errorf("Unknown ResourceType: %v", rType.Slug)
+		return "", "", "", "", "", "", fmt.Errorf("%w: %v", ErrUnsupportedResourceType, rType.Slug)
 	}
 	return resource.FolderParentID, name, username, uri, pw, desc, nil
 }

--- a/helper/resource_update.go
+++ b/helper/resource_update.go
@@ -99,7 +99,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 				metadataMap["uris"] = []string{uri}
 			}
 		default:
-			return fmt.Errorf("Unknown ResourceType: %v", rType.Slug)
+			return fmt.Errorf("%w: %v", ErrUnsupportedResourceType, rType.Slug)
 		}
 
 		newMetadata, err = json.Marshal(&metadataMap)
@@ -229,7 +229,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 			}
 			secretData = string(res)
 		default:
-			return fmt.Errorf("Unknown ResourceType: %v", rType.Slug)
+			return fmt.Errorf("%w: %v", ErrUnsupportedResourceType, rType.Slug)
 		}
 	} else {
 		// V4 Resource
@@ -345,7 +345,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 			}
 			secretData = string(res)
 		default:
-			return fmt.Errorf("Unknown ResourceType: %v", rType.Slug)
+			return fmt.Errorf("%w: %v", ErrUnsupportedResourceType, rType.Slug)
 		}
 	}
 

--- a/helper/secret.go
+++ b/helper/secret.go
@@ -25,7 +25,7 @@ func validateSecretData(rType *api.ResourceType, secretData string) error {
 	if string(definition) == "[]" || string(definition) == "\"[]\"" {
 		tmp, ok := api.ResourceSchemas[rType.Slug]
 		if !ok {
-			return fmt.Errorf("Server Does not have the Required json Schema and there is no fallback available for type: %v", rType.Slug)
+			return fmt.Errorf("%w: %v (no schema available)", ErrUnsupportedResourceType, rType.Slug)
 		}
 		definition = tmp
 	}


### PR DESCRIPTION
For now the commands crashes when a user having resources with custom fields tries to access or updates the resources.

This adds a specific error that the CLI can catch to continue instead of crashing.