### PR TITLE
PB-48450 - Fix duplicate JSON tag errors in ARO struct

### DIFF
--- a/api/gpgkey.go
+++ b/api/gpgkey.go
@@ -19,6 +19,8 @@ type GPGKey struct {
 	Fingerprint string `json:"fingerprint,omitempty"`
 	Type        string `json:"type,omitempty"`
 	Expires     *Time  `json:"expires,omitempty"`
+	UserID      string `json:"user_id,omitempty"`
+	UID         string `json:"uid,omitempty"`
 }
 
 // GetGPGKeysOptions are all available query parameters

--- a/api/groups.go
+++ b/api/groups.go
@@ -15,6 +15,7 @@ type Group struct {
 	Deleted    bool   `json:"deleted,omitempty"`
 	Modified   *Time  `json:"modified,omitempty"`
 	ModifiedBy string `json:"modified_by,omitempty"`
+	UserCount  int    `json:"user_count,omitempty"`
 	// This does not Contain Profile for Users Anymore...
 	GroupUsers []GroupMembership `json:"groups_users,omitempty"`
 	// This is new and undocumented but as all the data

--- a/api/roles.go
+++ b/api/roles.go
@@ -12,6 +12,10 @@ type Role struct {
 	Created     *Time  `json:"created,omitempty"`
 	Description string `json:"description,omitempty"`
 	Modified    *Time  `json:"modified,omitempty"`
+	CreatedBy   string `json:"created_by,omitempty"`
+	ModifiedBy  string `json:"modified_by,omitempty"`
+	Deleted     bool   `json:"deleted,omitempty"`
+	DeletedBy   string `json:"deleted_by,omitempty"`
 	Avatar      Avatar `json:"avatar,omitempty"`
 }
 

--- a/api/share.go
+++ b/api/share.go
@@ -35,8 +35,33 @@ type ResourceShareSimulationUser struct {
 
 // ARO is a User or a Group
 type ARO struct {
-	User
-	Group
+	User  `json:"-"`
+	Group `json:"-"`
+}
+
+// UnmarshalJSON implements custom unmarshaling for ARO.
+// The API returns a flat array mixing User and Group objects,
+// so we detect the type by checking for distinguishing fields.
+func (a *ARO) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Users have "username", Groups have "name" and "user_count"
+	if _, hasUsername := raw["username"]; hasUsername {
+		return json.Unmarshal(data, &a.User)
+	}
+	return json.Unmarshal(data, &a.Group)
+}
+
+// MarshalJSON implements custom marshaling for ARO.
+// It marshals the User if Username is set, otherwise the Group.
+func (a ARO) MarshalJSON() ([]byte, error) {
+	if a.Username != "" {
+		return json.Marshal(a.User)
+	}
+	return json.Marshal(a.Group)
 }
 
 // SearchAROsOptions are all available query parameters

--- a/api/users.go
+++ b/api/users.go
@@ -14,6 +14,7 @@ type User struct {
 	Created      *Time     `json:"created,omitempty"`
 	Active       bool      `json:"active,omitempty"`
 	Deleted      bool      `json:"deleted,omitempty"`
+	Disabled     bool      `json:"disabled,omitempty"`
 	Description  string    `json:"description,omitempty"`
 	Favorite     *Favorite `json:"favorite,omitempty"`
 	Modified     *Time     `json:"modified,omitempty"`
@@ -21,12 +22,15 @@ type User struct {
 	RoleID       string    `json:"role_id,omitempty"`
 	Profile      *Profile  `json:"profile,omitempty"`
 	Role         *Role     `json:"role,omitempty"`
-	GPGKey       *GPGKey   `json:"gpgKey,omitempty"`
+	GPGKey       *GPGKey   `json:"gpgkey,omitempty"`
 	LastLoggedIn string    `json:"last_logged_in,omitempty"`
 	Locale       string    `json:"locale,omitempty"`
 
 	// Admin only, needs contains
 	MissingMetadataKeyIDs []string `json:"missing_metadata_key_ids,omitempty"`
+
+	// GroupsUsers contains group membership data (returned by SearchAROs endpoint)
+	GroupsUsers []GroupMembership `json:"groups_users,omitempty"`
 }
 
 // Profile is a Profile
@@ -35,8 +39,9 @@ type Profile struct {
 	UserID    string `json:"user_id,omitempty"`
 	FirstName string `json:"first_name,omitempty"`
 	LastName  string `json:"last_name,omitempty"`
-	Created   *Time  `json:"created,omitempty"`
-	Modified  *Time  `json:"modified,omitempty"`
+	Created   *Time   `json:"created,omitempty"`
+	Modified  *Time   `json:"modified,omitempty"`
+	Avatar    *Avatar `json:"avatar,omitempty"`
 }
 
 // GetUsersOptions are all available query parameters

--- a/helper/resource_update.go
+++ b/helper/resource_update.go
@@ -383,7 +383,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 	passwordExpirySettings := c.GetPasswordExpirySettings()
 	if resource.Expired != nil && passwordExpirySettings.AutomaticUpdate {
 		expiry := time.Now().Add(time.Hour * 24 * time.Duration(passwordExpirySettings.DefaultExpiryPeriod))
-		newResource.Expired = &api.Time{expiry}
+		newResource.Expired = &api.Time{Time: expiry}
 	}
 
 	_, err = c.UpdateResource(ctx, resourceID, newResource)


### PR DESCRIPTION
# Summary

- Fix `go vet` errors that were preventing clean builds
- Add missing fields to SDK structs to match actual Passbolt API responses
- Preserve full API data during JSON round-trips

# Changes

## Bug Fixes

**ARO struct duplicate JSON tags** (`api/share.go`)
- The ARO struct embedded both User and Group, which share overlapping JSON tags (`id`, `created`, `deleted`, `modified`)
- This caused `go vet` to fail with duplicate JSON tag errors
- Fixed by using `json:"-"` on embedded structs and implementing custom `UnmarshalJSON`/`MarshalJSON` methods
- The custom marshaling correctly detects User vs Group by checking for the `username` field

**Unkeyed struct literal** (`helper/resource_update.go`)
- Changed `&api.Time{expiry}` to `&api.Time{Time: expiry}` to use keyed field syntax

## New Fields

Added missing fields to match Passbolt API responses:

| Struct | New Fields |
|--------|------------|
| `User` | `Disabled`, `GroupsUsers` |
| `Profile` | `Avatar` |
| `Group` | `UserCount` |
| `Role` | `CreatedBy`, `ModifiedBy`, `Deleted`, `DeletedBy` |
| `GPGKey` | `UserID`, `UID` |

## JSON Tag Fix

- Changed `User.GPGKey` JSON tag from `gpgKey` to `gpgkey` to match API response format