### PR TITLE
PB-49603 - Go-cli re-enable staticcheck rules

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -52,18 +52,18 @@ func (c *Client) DoCustomRequestAndReturnRawResponseV5(ctx context.Context, meth
 start:
 	u, err := generateURL(*c.baseURL, path, opts)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Generating Path: %w", err)
+		return nil, nil, fmt.Errorf("generating Path: %w", err)
 	}
 
 	req, err := c.newRequest(method, u, body)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Creating New Request: %w", err)
+		return nil, nil, fmt.Errorf("creating New Request: %w", err)
 	}
 
 	var res APIResponse
 	r, err := c.do(ctx, req, &res)
 	if err != nil {
-		return r, &res, fmt.Errorf("Doing Request: %w", err)
+		return r, &res, fmt.Errorf("doing Request: %w", err)
 	}
 
 	// Because of MFA i need to do the csrf token stuff here
@@ -81,18 +81,18 @@ start:
 		if res.Header.Code == 403 && strings.HasSuffix(res.Header.URL, "/mfa/verify/error.json") {
 			if !firstTime {
 				// if we are here this probably means that the MFA callback is broken, to prevent a infinite loop lets error here
-				return r, &res, fmt.Errorf("Got MFA challenge twice in a row, is your MFA Callback broken? Bailing to prevent loop...:")
+				return r, &res, fmt.Errorf("got MFA challenge twice in a row, is your MFA callback broken? bailing to prevent loop")
 			}
 			if c.MFACallback != nil {
 				c.mfaToken, err = c.MFACallback(ctx, c, &res)
 				if err != nil {
-					return r, &res, fmt.Errorf("MFA Callback: %w", err)
+					return r, &res, fmt.Errorf("handling MFA callback: %w", err)
 				}
 				// ok, we got the MFA challenge and the callback presumably handled it so we can retry the original request
 				firstTime = false
 				goto start
 			} else {
-				return r, &res, fmt.Errorf("Got MFA Challenge but the MFA callback is not defined")
+				return r, &res, fmt.Errorf("got MFA Challenge but the MFA callback is not defined")
 			}
 		}
 		return r, &res, fmt.Errorf("%w: Message: %v, Body: %v", ErrAPIResponseErrorStatusCode, res.Header.Message, string(res.Body))

--- a/api/api.go
+++ b/api/api.go
@@ -81,7 +81,7 @@ start:
 		if res.Header.Code == 403 && strings.HasSuffix(res.Header.URL, "/mfa/verify/error.json") {
 			if !firstTime {
 				// if we are here this probably means that the MFA callback is broken, to prevent a infinite loop lets error here
-				return r, &res, fmt.Errorf("got MFA challenge twice in a row, is your MFA callback broken? bailing to prevent loop")
+				return r, &res, fmt.Errorf("%w: got MFA challenge twice in a row, is your MFA callback broken? bailing to prevent loop", ErrMFAFailed)
 			}
 			if c.MFACallback != nil {
 				c.mfaToken, err = c.MFACallback(ctx, c, &res)
@@ -92,11 +92,11 @@ start:
 				firstTime = false
 				goto start
 			} else {
-				return r, &res, fmt.Errorf("got MFA Challenge but the MFA callback is not defined")
+				return r, &res, ErrMFACallbackMissing
 			}
 		}
-		return r, &res, fmt.Errorf("%w: Message: %v, Body: %v", ErrAPIResponseErrorStatusCode, res.Header.Message, string(res.Body))
+		return r, &res, &APIError{StatusCode: res.Header.Code, Message: res.Header.Message, Body: string(res.Body)}
 	} else {
-		return r, &res, fmt.Errorf("%w: Message: %v, Body: %v", ErrAPIResponseUnknownStatusCode, res.Header.Message, string(res.Body))
+		return r, &res, &APIError{StatusCode: res.Header.Code, Message: res.Header.Message, Body: string(res.Body)}
 	}
 }

--- a/api/auth.go
+++ b/api/auth.go
@@ -33,7 +33,7 @@ func (c *Client) Login(ctx context.Context) error {
 	c.cryptoMu.RLock()
 	if c.userPrivateKey == nil {
 		c.cryptoMu.RUnlock()
-		return fmt.Errorf("Cannot login: client has no user private key (logged out or not initialized)")
+		return fmt.Errorf("cannot login: client has no user private key (logged out or not initialized)")
 	}
 	fingerprint := c.userPrivateKey.GetFingerprint()
 	c.cryptoMu.RUnlock()
@@ -46,40 +46,40 @@ func (c *Client) Login(ctx context.Context) error {
 
 	res, _, err := c.DoCustomRequestAndReturnRawResponse(ctx, "POST", "/auth/login.json", "v2", data, nil)
 	if err != nil && !strings.Contains(err.Error(), "Error API JSON Response Status: Message: The authentication failed.") {
-		return fmt.Errorf("Doing Stage 1 Request: %w", err)
+		return fmt.Errorf("doing Stage 1 Request: %w", err)
 	}
 
 	encAuthToken := res.Header.Get("X-GPGAuth-User-Auth-Token")
 
 	if encAuthToken == "" {
-		return fmt.Errorf("Got Empty X-GPGAuth-User-Auth-Token Header")
+		return fmt.Errorf("got Empty X-GPGAuth-User-Auth-Token Header")
 	}
 
 	c.log("Got Encrypted Auth Token: %v", encAuthToken)
 
 	encAuthToken, err = url.QueryUnescape(encAuthToken)
 	if err != nil {
-		return fmt.Errorf("Unescaping User Auth Token: %w", err)
+		return fmt.Errorf("unescaping User Auth Token: %w", err)
 	}
 	encAuthToken = strings.ReplaceAll(encAuthToken, "\\ ", " ")
 
 	authToken, err := c.DecryptMessage(encAuthToken)
 	if err != nil {
-		return fmt.Errorf("Decrypting User Auth Token: %w", err)
+		return fmt.Errorf("decrypting User Auth Token: %w", err)
 	}
 
 	c.log("Decrypted Auth Token: %v", authToken)
 
 	err = checkAuthTokenFormat(authToken)
 	if err != nil {
-		return fmt.Errorf("Checking Auth Token Format: %w", err)
+		return fmt.Errorf("checking Auth Token Format: %w", err)
 	}
 
 	data.Auth.Token = string(authToken)
 
 	res, _, err = c.DoCustomRequestAndReturnRawResponse(ctx, "POST", "/auth/login.json", "v2", data, nil)
 	if err != nil {
-		return fmt.Errorf("Doing Stage 2 Request: %w", err)
+		return fmt.Errorf("doing Stage 2 Request: %w", err)
 	}
 
 	c.log("Got Cookies: %+v", res.Cookies())
@@ -96,38 +96,38 @@ func (c *Client) Login(ctx context.Context) error {
 		}
 	}
 	if c.sessionToken.Name == "" {
-		return fmt.Errorf("Cannot Find Session Cookie!")
+		return fmt.Errorf("cannot find session cookie")
 	}
 
 	// Because of MFA, the custom Request Function now Fetches the CSRF token, we still need the user for his public key
 	apiMsg, err := c.DoCustomRequest(ctx, "GET", "/users/me.json", "v2", nil, nil)
 	if err != nil {
-		return fmt.Errorf("Getting CSRF Token: %w", err)
+		return fmt.Errorf("getting CSRF Token: %w", err)
 	}
 
 	// Get Users ID from Server
 	var user User
 	err = json.Unmarshal(apiMsg.Body, &user)
 	if err != nil {
-		return fmt.Errorf("Parsing User 'Me' JSON from API Request: %w", err)
+		return fmt.Errorf("parsing User 'Me' JSON from API Request: %w", err)
 	}
 
 	c.userID = user.ID
 
 	settings, err := c.GetServerSettings(ctx)
 	if err != nil {
-		return fmt.Errorf("Getting Server Settings: %w", err)
+		return fmt.Errorf("getting Server Settings: %w", err)
 	}
 
 	// after Login, fetch MetadataTypeSettings to finish the Client Setup
 	err = c.setMetadataTypeSettings(ctx, settings)
 	if err != nil {
-		return fmt.Errorf("Setup Metadata Type Settings: %w", err)
+		return fmt.Errorf("setup Metadata Type Settings: %w", err)
 	}
 
 	err = c.setPasswordExpirySettings(ctx, settings)
 	if err != nil {
-		return fmt.Errorf("Setup Password Expiry Settings: %w", err)
+		return fmt.Errorf("setup Password Expiry Settings: %w", err)
 	}
 
 	// Pre-fetch caches if server supports v5 metadata encryption
@@ -152,7 +152,7 @@ func (c *Client) Login(ctx context.Context) error {
 func (c *Client) Logout(ctx context.Context) error {
 	_, err := c.DoCustomRequest(ctx, "GET", "/auth/logout.json", "v2", nil, nil)
 	if err != nil {
-		return fmt.Errorf("Doing Logout Request: %w", err)
+		return fmt.Errorf("doing Logout Request: %w", err)
 	}
 
 	// Clear session cookies

--- a/api/auth.go
+++ b/api/auth.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -33,7 +34,7 @@ func (c *Client) Login(ctx context.Context) error {
 	c.cryptoMu.RLock()
 	if c.userPrivateKey == nil {
 		c.cryptoMu.RUnlock()
-		return fmt.Errorf("cannot login: client has no user private key (logged out or not initialized)")
+		return fmt.Errorf("cannot login: %w", ErrNoPrivateKey)
 	}
 	fingerprint := c.userPrivateKey.GetFingerprint()
 	c.cryptoMu.RUnlock()
@@ -45,14 +46,15 @@ func (c *Client) Login(ctx context.Context) error {
 	data := Login{&GPGAuth{KeyID: fingerprint}}
 
 	res, _, err := c.DoCustomRequestAndReturnRawResponse(ctx, "POST", "/auth/login.json", "v2", data, nil)
-	if err != nil && !strings.Contains(err.Error(), "Error API JSON Response Status: Message: The authentication failed.") {
+	var apiErr *APIError
+	if err != nil && !(errors.As(err, &apiErr) && apiErr.Message == "The authentication failed.") {
 		return fmt.Errorf("doing Stage 1 Request: %w", err)
 	}
 
 	encAuthToken := res.Header.Get("X-GPGAuth-User-Auth-Token")
 
 	if encAuthToken == "" {
-		return fmt.Errorf("got Empty X-GPGAuth-User-Auth-Token Header")
+		return ErrEmptyAuthToken
 	}
 
 	c.log("Got Encrypted Auth Token: %v", encAuthToken)
@@ -96,7 +98,7 @@ func (c *Client) Login(ctx context.Context) error {
 		}
 	}
 	if c.sessionToken.Name == "" {
-		return fmt.Errorf("cannot find session cookie")
+		return ErrSessionNotFound
 	}
 
 	// Because of MFA, the custom Request Function now Fetches the CSRF token, we still need the user for his public key

--- a/api/cache_unit_test.go
+++ b/api/cache_unit_test.go
@@ -134,7 +134,7 @@ func TestSessionKeyCacheOperations(t *testing.T) {
 
 		retrieved := client.GetSessionKeyByResourceID(resourceID)
 		if retrieved == nil {
-			t.Error("GetSessionKeyByResourceID returned nil")
+			t.Fatal("GetSessionKeyByResourceID returned nil")
 		}
 		// Compare contents, not pointers (getters return clones)
 		if retrieved.Algo != sessionKey.Algo || string(retrieved.Key) != string(sessionKey.Key) {
@@ -155,7 +155,7 @@ func TestSessionKeyCacheOperations(t *testing.T) {
 
 		retrieved := client.GetSessionKeyByMetadataKeyID(metadataKeyID)
 		if retrieved == nil {
-			t.Error("GetSessionKeyByMetadataKeyID returned nil")
+			t.Fatal("GetSessionKeyByMetadataKeyID returned nil")
 		}
 		// Compare contents, not pointers (getters return clones)
 		if retrieved.Algo != sessionKey2.Algo || string(retrieved.Key) != string(sessionKey2.Key) {

--- a/api/client.go
+++ b/api/client.go
@@ -422,7 +422,7 @@ func (c *Client) GetResourceTypeCached(ctx context.Context, typeID string) (*Res
 		}
 	}
 
-	return nil, fmt.Errorf("resource type not found: %v", typeID)
+	return nil, fmt.Errorf("%w: %v", ErrResourceTypeNotFound, typeID)
 }
 
 // GetResourceTypeBySlugCached returns a cached resource type by slug
@@ -438,7 +438,7 @@ func (c *Client) GetResourceTypeBySlugCached(ctx context.Context, slug string) (
 		}
 	}
 
-	return nil, fmt.Errorf("resource type not found: %v", slug)
+	return nil, fmt.Errorf("%w: %v", ErrResourceTypeNotFound, slug)
 }
 
 // GetMetadataKeysCached returns cached metadata keys, fetching from API if cache is empty
@@ -496,11 +496,11 @@ func (c *Client) GetDecryptedMetadataKeyCached(ctx context.Context, id string) (
 	}
 
 	if metadataKey == nil {
-		return nil, fmt.Errorf("metadata key not found: %v", id)
+		return nil, fmt.Errorf("%w: %v", ErrMetadataKeyNotFound, id)
 	}
 
 	if len(metadataKey.MetadataPrivateKeys) == 0 {
-		return nil, fmt.Errorf("no Metadata Private key for our user")
+		return nil, ErrNoMetadataPrivateKey
 	}
 
 	// Find our user's private key
@@ -513,7 +513,7 @@ func (c *Client) GetDecryptedMetadataKeyCached(ctx context.Context, id string) (
 	}
 
 	if privMetadata == nil {
-		return nil, fmt.Errorf("no Metadata Private key for our user id: %v", c.userID)
+		return nil, fmt.Errorf("%w: user id %v", ErrNoMetadataPrivateKey, c.userID)
 	}
 
 	decPrivMetadatakey, err := c.DecryptMessage(privMetadata.Data)

--- a/api/client.go
+++ b/api/client.go
@@ -117,7 +117,7 @@ func NewClient(httpClient *http.Client, UserAgent, BaseURL, UserPrivateKey, User
 
 	u, err := url.Parse(BaseURL)
 	if err != nil {
-		return nil, fmt.Errorf("Parsing Base URL: %w", err)
+		return nil, fmt.Errorf("parsing Base URL: %w", err)
 	}
 
 	pgp := crypto.PGP()
@@ -126,7 +126,7 @@ func NewClient(httpClient *http.Client, UserAgent, BaseURL, UserPrivateKey, User
 	if UserPrivateKey != "" {
 		key, err := GetPrivateKeyFromArmor(UserPrivateKey, []byte(UserPassword))
 		if err != nil {
-			return nil, fmt.Errorf("Get Private Key: %w", err)
+			return nil, fmt.Errorf("get Private Key: %w", err)
 		}
 		unlockedKey = key
 	}
@@ -151,13 +151,13 @@ func (c *Client) newRequest(method, url string, body interface{}) (*http.Request
 		buf = new(bytes.Buffer)
 		err := json.NewEncoder(buf).Encode(body)
 		if err != nil {
-			return nil, fmt.Errorf("JSON Encoding Request: %w", err)
+			return nil, fmt.Errorf("jSON Encoding Request: %w", err)
 		}
 	}
 
 	req, err := http.NewRequest(method, url, buf)
 	if err != nil {
-		return nil, fmt.Errorf("Creating HTTP Request: %w", err)
+		return nil, fmt.Errorf("creating HTTP Request: %w", err)
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
@@ -189,9 +189,9 @@ func (c *Client) do(ctx context.Context, req *http.Request, v *APIResponse) (*ht
 	if err != nil {
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("Request Context: %w", ctx.Err())
+			return nil, fmt.Errorf("request Context: %w", ctx.Err())
 		default:
-			return nil, fmt.Errorf("Request: %w", err)
+			return nil, fmt.Errorf("request: %w", err)
 		}
 	}
 	defer func() {
@@ -200,14 +200,14 @@ func (c *Client) do(ctx context.Context, req *http.Request, v *APIResponse) (*ht
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return resp, fmt.Errorf("Error Reading Resopnse Body: %w", err)
+		return resp, fmt.Errorf("error Reading Resopnse Body: %w", err)
 	}
 
 	c.log("Raw Response: %v", string(bodyBytes))
 
 	err = json.Unmarshal(bodyBytes, v)
 	if err != nil {
-		return resp, fmt.Errorf("Unable to Parse JSON API Response with HTTP Status Code %v: %w", resp.StatusCode, err)
+		return resp, fmt.Errorf("unable to Parse JSON API Response with HTTP Status Code %v: %w", resp.StatusCode, err)
 	}
 
 	return resp, nil
@@ -224,7 +224,7 @@ func generateURL(base url.URL, p string, opt interface{}) (string, error) {
 	base.Path = path.Join(base.Path, p)
 	vs, err := query.Values(opt)
 	if err != nil {
-		return "", fmt.Errorf("Getting URL Query Values: %w", err)
+		return "", fmt.Errorf("getting URL Query Values: %w", err)
 	}
 	base.RawQuery = vs.Encode()
 
@@ -240,19 +240,19 @@ func (c *Client) GetUserID() string {
 func (c *Client) GetPublicKey(ctx context.Context) (string, string, error) {
 	msg, err := c.DoCustomRequest(ctx, "GET", "/auth/verify.json", "v2", nil, nil)
 	if err != nil {
-		return "", "", fmt.Errorf("Doing Request: %w", err)
+		return "", "", fmt.Errorf("doing Request: %w", err)
 	}
 
 	var body PublicKeyReponse
 	err = json.Unmarshal(msg.Body, &body)
 	if err != nil {
-		return "", "", fmt.Errorf("Parsing JSON: %w", err)
+		return "", "", fmt.Errorf("parsing JSON: %w", err)
 	}
 
 	// Lets get the actual Fingerprint instead of trusting the Server
 	serverKey, err := crypto.NewKeyFromArmored(body.Keydata)
 	if err != nil {
-		return "", "", fmt.Errorf("Parsing Server Key: %w", err)
+		return "", "", fmt.Errorf("parsing Server Key: %w", err)
 	}
 	return body.Keydata, serverKey.GetFingerprint(), nil
 }
@@ -263,7 +263,7 @@ func (c *Client) setMetadataTypeSettings(ctx context.Context, settings *ServerSe
 		c.log("Server has metadata plugin enabled, is v5 or Higher")
 		metadataTypeSettings, err := c.GetServerMetadataTypeSettings(ctx)
 		if err != nil {
-			return fmt.Errorf("Getting Metadata Type Settings: %w", err)
+			return fmt.Errorf("getting Metadata Type Settings: %w", err)
 		}
 
 		c.log("metadataTypeSettings: %+v", metadataTypeSettings)
@@ -271,7 +271,7 @@ func (c *Client) setMetadataTypeSettings(ctx context.Context, settings *ServerSe
 
 		metadataKeySettings, err := c.GetServerMetadataKeySettings(ctx)
 		if err != nil {
-			return fmt.Errorf("Getting Metadata Key Settings: %w", err)
+			return fmt.Errorf("getting Metadata Key Settings: %w", err)
 		}
 
 		c.log("metadataKeySettings: %+v", metadataKeySettings)
@@ -293,7 +293,7 @@ func (c *Client) setPasswordExpirySettings(ctx context.Context, settings *Server
 		c.log("Server has password expiry plugin enabled.")
 		passwordExpirySettings, err := c.getServerPasswordExpirySettings(ctx)
 		if err != nil {
-			return fmt.Errorf("Getting Password Expiry Settings: %w", err)
+			return fmt.Errorf("getting Password Expiry Settings: %w", err)
 		}
 
 		c.log("passwordExpirySettings: %+v", passwordExpirySettings)
@@ -474,7 +474,7 @@ func (c *Client) GetDecryptedMetadataKeyCached(ctx context.Context, id string) (
 		keyCopy, err := key.Copy()
 		c.cryptoMu.Unlock()
 		if err != nil {
-			return nil, fmt.Errorf("Copy Cached Metadata Key: %w", err)
+			return nil, fmt.Errorf("copy Cached Metadata Key: %w", err)
 		}
 		return keyCopy, nil
 	}
@@ -483,7 +483,7 @@ func (c *Client) GetDecryptedMetadataKeyCached(ctx context.Context, id string) (
 	// Get metadata keys (from cache or API)
 	keys, err := c.GetMetadataKeysCached(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Get Metadata Keys: %w", err)
+		return nil, fmt.Errorf("get Metadata Keys: %w", err)
 	}
 
 	// Find the key with matching ID
@@ -496,11 +496,11 @@ func (c *Client) GetDecryptedMetadataKeyCached(ctx context.Context, id string) (
 	}
 
 	if metadataKey == nil {
-		return nil, fmt.Errorf("Metadata key not found: %v", id)
+		return nil, fmt.Errorf("metadata key not found: %v", id)
 	}
 
 	if len(metadataKey.MetadataPrivateKeys) == 0 {
-		return nil, fmt.Errorf("No Metadata Private key for our user")
+		return nil, fmt.Errorf("no Metadata Private key for our user")
 	}
 
 	// Find our user's private key
@@ -513,23 +513,23 @@ func (c *Client) GetDecryptedMetadataKeyCached(ctx context.Context, id string) (
 	}
 
 	if privMetadata == nil {
-		return nil, fmt.Errorf("No Metadata Private key for our user id: %v", c.userID)
+		return nil, fmt.Errorf("no Metadata Private key for our user id: %v", c.userID)
 	}
 
 	decPrivMetadatakey, err := c.DecryptMessage(privMetadata.Data)
 	if err != nil {
-		return nil, fmt.Errorf("Decrypt Metadata Private Key Data: %w", err)
+		return nil, fmt.Errorf("decrypt Metadata Private Key Data: %w", err)
 	}
 
 	var data MetadataPrivateKeyData
 	err = json.Unmarshal([]byte(decPrivMetadatakey), &data)
 	if err != nil {
-		return nil, fmt.Errorf("Parse Metadata Private Key Data: %w", err)
+		return nil, fmt.Errorf("parse Metadata Private Key Data: %w", err)
 	}
 
 	metadataPrivateKeyObj, err := GetPrivateKeyFromArmor(data.ArmoredKey, []byte(data.Passphrase))
 	if err != nil {
-		return nil, fmt.Errorf("Get Metadata Private Key: %w", err)
+		return nil, fmt.Errorf("get Metadata Private Key: %w", err)
 	}
 
 	// Cache the decrypted key
@@ -538,7 +538,7 @@ func (c *Client) GetDecryptedMetadataKeyCached(ctx context.Context, id string) (
 	// Return a copy so caller cannot affect cached key
 	keyCopy, err := metadataPrivateKeyObj.Copy()
 	if err != nil {
-		return nil, fmt.Errorf("Copy Metadata Key: %w", err)
+		return nil, fmt.Errorf("copy Metadata Key: %w", err)
 	}
 	return keyCopy, nil
 }
@@ -550,7 +550,7 @@ func (c *Client) PreDecryptAllMetadataPrivateKeys(ctx context.Context) (int, err
 	// Fetch all metadata keys (this will also fetch the private keys for our user)
 	keys, err := c.GetMetadataKeysCached(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("Get Metadata Keys: %w", err)
+		return 0, fmt.Errorf("get Metadata Keys: %w", err)
 	}
 
 	decrypted := 0

--- a/api/comments.go
+++ b/api/comments.go
@@ -32,7 +32,7 @@ type GetCommentsOptions struct {
 func (c *Client) GetComments(ctx context.Context, resourceID string, opts *GetCommentsOptions) ([]Comment, error) {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "GET", "/comments/resource/"+resourceID+".json", "v2", nil, opts)
 	if err != nil {
@@ -51,7 +51,7 @@ func (c *Client) GetComments(ctx context.Context, resourceID string, opts *GetCo
 func (c *Client) CreateComment(ctx context.Context, resourceID string, comment Comment) (*Comment, error) {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "POST", "/comments/resource/"+resourceID+".json", "v2", comment, nil)
 	if err != nil {
@@ -69,7 +69,7 @@ func (c *Client) CreateComment(ctx context.Context, resourceID string, comment C
 func (c *Client) UpdateComment(ctx context.Context, commentID string, comment Comment) (*Comment, error) {
 	err := checkUUIDFormat(commentID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "PUT", "/comments/"+commentID+".json", "v2", comment, nil)
 	if err != nil {
@@ -87,7 +87,7 @@ func (c *Client) UpdateComment(ctx context.Context, commentID string, comment Co
 func (c *Client) DeleteComment(ctx context.Context, commentID string) error {
 	err := checkUUIDFormat(commentID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequest(ctx, "DELETE", "/comments/"+commentID+".json", "v2", nil, nil)
 	if err != nil {

--- a/api/doc.go
+++ b/api/doc.go
@@ -1,0 +1,2 @@
+// Package api provides a low-level client for the Passbolt API.
+package api

--- a/api/encryption.go
+++ b/api/encryption.go
@@ -13,7 +13,7 @@ func (c *Client) EncryptMessage(message string) (string, error) {
 	defer c.cryptoMu.RUnlock()
 
 	if c.userPrivateKey == nil {
-		return "", fmt.Errorf("client has no user private key (logged out or not initialized)")
+		return "", ErrNoPrivateKey
 	}
 
 	key, err := c.userPrivateKey.Copy()
@@ -59,7 +59,7 @@ func (c *Client) EncryptMessageWithKey(publicKey *crypto.Key, message string) (s
 	defer c.cryptoMu.RUnlock()
 
 	if c.userPrivateKey == nil {
-		return "", fmt.Errorf("client has no user private key (logged out or not initialized)")
+		return "", ErrNoPrivateKey
 	}
 
 	key, err := c.userPrivateKey.Copy()
@@ -93,7 +93,7 @@ func (c *Client) DecryptMessage(armoredCiphertext string) (string, error) {
 	defer c.cryptoMu.RUnlock()
 
 	if c.userPrivateKey == nil {
-		return "", fmt.Errorf("client has no user private key (logged out or not initialized)")
+		return "", ErrNoPrivateKey
 	}
 
 	key, err := c.userPrivateKey.Copy()
@@ -212,7 +212,7 @@ func (c *Client) GetUserPrivateKeyCopy() (*crypto.Key, error) {
 	defer c.cryptoMu.RUnlock()
 
 	if c.userPrivateKey == nil {
-		return nil, fmt.Errorf("client has no user private key (logged out or not initialized)")
+		return nil, ErrNoPrivateKey
 	}
 
 	key, err := c.userPrivateKey.Copy()

--- a/api/encryption.go
+++ b/api/encryption.go
@@ -13,29 +13,29 @@ func (c *Client) EncryptMessage(message string) (string, error) {
 	defer c.cryptoMu.RUnlock()
 
 	if c.userPrivateKey == nil {
-		return "", fmt.Errorf("Client has no user private key (logged out or not initialized)")
+		return "", fmt.Errorf("client has no user private key (logged out or not initialized)")
 	}
 
 	key, err := c.userPrivateKey.Copy()
 	if err != nil {
-		return "", fmt.Errorf("Get Private Key Copy: %w", err)
+		return "", fmt.Errorf("get Private Key Copy: %w", err)
 	}
 
 	encHandle, err := c.pgp.Encryption().SigningKey(key).Recipient(c.userPrivateKey).New()
 	if err != nil {
-		return "", fmt.Errorf("New Encryptor: %w", err)
+		return "", fmt.Errorf("new Encryptor: %w", err)
 	}
 
 	defer encHandle.ClearPrivateParams()
 
 	encMessage, err := encHandle.Encrypt([]byte(message))
 	if err != nil {
-		return "", fmt.Errorf("Encrypt Message: %w", err)
+		return "", fmt.Errorf("encrypt Message: %w", err)
 	}
 
 	encArmor, err := encMessage.Armor()
 	if err != nil {
-		return "", fmt.Errorf("Armor Message: %w", err)
+		return "", fmt.Errorf("armor Message: %w", err)
 	}
 	return encArmor, nil
 }
@@ -46,7 +46,7 @@ func (c *Client) EncryptMessage(message string) (string, error) {
 func (c *Client) EncryptMessageWithPublicKey(publickey, message string) (string, error) {
 	publicKey, err := crypto.NewKeyFromArmored(publickey)
 	if err != nil {
-		return "", fmt.Errorf("Get Public Key: %w", err)
+		return "", fmt.Errorf("get Public Key: %w", err)
 	}
 
 	return c.EncryptMessageWithKey(publicKey, message)
@@ -59,29 +59,29 @@ func (c *Client) EncryptMessageWithKey(publicKey *crypto.Key, message string) (s
 	defer c.cryptoMu.RUnlock()
 
 	if c.userPrivateKey == nil {
-		return "", fmt.Errorf("Client has no user private key (logged out or not initialized)")
+		return "", fmt.Errorf("client has no user private key (logged out or not initialized)")
 	}
 
 	key, err := c.userPrivateKey.Copy()
 	if err != nil {
-		return "", fmt.Errorf("Get Private Key Copy: %w", err)
+		return "", fmt.Errorf("get Private Key Copy: %w", err)
 	}
 
 	encHandle, err := c.pgp.Encryption().SigningKey(key).Recipient(publicKey).New()
 	if err != nil {
-		return "", fmt.Errorf("New Encryptor: %w", err)
+		return "", fmt.Errorf("new Encryptor: %w", err)
 	}
 
 	defer encHandle.ClearPrivateParams()
 
 	encMessage, err := encHandle.Encrypt([]byte(message))
 	if err != nil {
-		return "", fmt.Errorf("Encrypt Message: %w", err)
+		return "", fmt.Errorf("encrypt Message: %w", err)
 	}
 
 	encArmor, err := encMessage.Armor()
 	if err != nil {
-		return "", fmt.Errorf("Armor Message: %w", err)
+		return "", fmt.Errorf("armor Message: %w", err)
 	}
 	return encArmor, nil
 }
@@ -93,12 +93,12 @@ func (c *Client) DecryptMessage(armoredCiphertext string) (string, error) {
 	defer c.cryptoMu.RUnlock()
 
 	if c.userPrivateKey == nil {
-		return "", fmt.Errorf("Client has no user private key (logged out or not initialized)")
+		return "", fmt.Errorf("client has no user private key (logged out or not initialized)")
 	}
 
 	key, err := c.userPrivateKey.Copy()
 	if err != nil {
-		return "", fmt.Errorf("Get Private Key Copy: %w", err)
+		return "", fmt.Errorf("get Private Key Copy: %w", err)
 	}
 
 	message, _, err := c.decryptMessageWithPrivateKeyAndReturnSessionKeyLocked(key, armoredCiphertext)
@@ -132,7 +132,7 @@ func (c *Client) decryptMessageWithPrivateKeyAndReturnSessionKeyLocked(privateKe
 	// (either by passing a copy or by external synchronization).
 	keyCopy, err := privateKey.Copy()
 	if err != nil {
-		return "", nil, fmt.Errorf("Copy Private Key: %w", err)
+		return "", nil, fmt.Errorf("copy Private Key: %w", err)
 	}
 
 	return c.decryptMessageWithPrivateKeyDirect(keyCopy, armoredCiphertext)
@@ -148,14 +148,14 @@ func (c *Client) decryptMessageWithPrivateKeyDirect(privateKey *crypto.Key, armo
 		RetrieveSessionKey().
 		New()
 	if err != nil {
-		return "", nil, fmt.Errorf("New Decryptor: %w", err)
+		return "", nil, fmt.Errorf("new Decryptor: %w", err)
 	}
 
 	defer decHandle.ClearPrivateParams()
 
 	res, err := decHandle.Decrypt([]byte(armoredCiphertext), crypto.Armor)
 	if err != nil {
-		return "", nil, fmt.Errorf("Decrypt: %w", err)
+		return "", nil, fmt.Errorf("decrypt: %w", err)
 	}
 
 	// Clone the session key before returning it, as ClearPrivateParams() will zero it out
@@ -170,18 +170,18 @@ func (c *Client) decryptMessageWithPrivateKeyDirect(privateKey *crypto.Key, armo
 func GetPrivateKeyFromArmor(privateKey string, passphrase []byte) (*crypto.Key, error) {
 	key, err := crypto.NewKeyFromArmored(privateKey)
 	if err != nil {
-		return nil, fmt.Errorf("Key From Armored: %w", err)
+		return nil, fmt.Errorf("key From Armored: %w", err)
 	}
 
 	locked, err := key.IsLocked()
 	if err != nil {
-		return nil, fmt.Errorf("Is Key Locked: %w", err)
+		return nil, fmt.Errorf("is Key Locked: %w", err)
 	}
 
 	if locked {
 		unlocked, err := key.Unlock(passphrase)
 		if err != nil {
-			return nil, fmt.Errorf("Unlock Key: %w", err)
+			return nil, fmt.Errorf("unlock Key: %w", err)
 		}
 		return unlocked, nil
 	}
@@ -192,14 +192,14 @@ func GetPrivateKeyFromArmor(privateKey string, passphrase []byte) (*crypto.Key, 
 func (c *Client) DecryptMessageWithSessionKey(sessionKey *crypto.SessionKey, ciphertextArmored string) (string, error) {
 	decHandle, err := c.pgp.Decryption().SessionKey(sessionKey).New()
 	if err != nil {
-		return "", fmt.Errorf("New Decryptor: %w", err)
+		return "", fmt.Errorf("new Decryptor: %w", err)
 	}
 
 	defer decHandle.ClearPrivateParams()
 
 	res, err := decHandle.Decrypt([]byte(ciphertextArmored), crypto.Armor)
 	if err != nil {
-		return "", fmt.Errorf("Decrypt: %w", err)
+		return "", fmt.Errorf("decrypt: %w", err)
 	}
 
 	return res.String(), nil
@@ -212,12 +212,12 @@ func (c *Client) GetUserPrivateKeyCopy() (*crypto.Key, error) {
 	defer c.cryptoMu.RUnlock()
 
 	if c.userPrivateKey == nil {
-		return nil, fmt.Errorf("Client has no user private key (logged out or not initialized)")
+		return nil, fmt.Errorf("client has no user private key (logged out or not initialized)")
 	}
 
 	key, err := c.userPrivateKey.Copy()
 	if err != nil {
-		return nil, fmt.Errorf("Get Private Key Copy: %w", err)
+		return nil, fmt.Errorf("get Private Key Copy: %w", err)
 	}
 	return key, nil
 }

--- a/api/errors.go
+++ b/api/errors.go
@@ -4,6 +4,6 @@ import "errors"
 
 var (
 	// API Error Codes
-	ErrAPIResponseErrorStatusCode   = errors.New("Error API JSON Response Status")
-	ErrAPIResponseUnknownStatusCode = errors.New("Unknown API JSON Response Status")
+	ErrAPIResponseErrorStatusCode   = errors.New("error API JSON Response Status")
+	ErrAPIResponseUnknownStatusCode = errors.New("unknown API JSON Response Status")
 )

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,9 +1,56 @@
 package api
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrAPIResponseErrorStatusCode indicates the API returned an error status.
+//
+// Deprecated: Use errors.As with *APIError instead.
+var ErrAPIResponseErrorStatusCode = errors.New("error API JSON Response Status")
+
+// ErrAPIResponseUnknownStatusCode indicates the API returned an unknown status.
+//
+// Deprecated: Use errors.As with *APIError instead.
+var ErrAPIResponseUnknownStatusCode = errors.New("unknown API JSON Response Status")
 
 var (
-	// API Error Codes
-	ErrAPIResponseErrorStatusCode   = errors.New("error API JSON Response Status")
-	ErrAPIResponseUnknownStatusCode = errors.New("unknown API JSON Response Status")
+	// Authentication & session errors
+	ErrNoPrivateKey       = errors.New("client has no user private key")
+	ErrSessionNotFound    = errors.New("cannot find session cookie")
+	ErrEmptyAuthToken     = errors.New("got empty X-GPGAuth-User-Auth-Token header")
+	ErrMFAFailed          = errors.New("MFA challenge failed")
+	ErrMFACallbackMissing = errors.New("MFA callback is not defined")
+
+	// Data lookup errors
+	ErrResourceTypeNotFound = errors.New("resource type not found")
+	ErrMetadataKeyNotFound  = errors.New("metadata key not found")
+	ErrNoMetadataPrivateKey = errors.New("no metadata private key for user")
+	ErrInvalidUUID          = errors.New("UUID is not in valid format")
 )
+
+// APIError represents a structured error from the Passbolt API response.
+// It carries the HTTP status code, server message, and response body,
+// allowing consumers to inspect error details programmatically via errors.As.
+type APIError struct {
+	StatusCode int
+	Message    string
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error (code %d): %s", e.StatusCode, e.Message)
+}
+
+// Is supports backward compatibility with the deprecated sentinel errors.
+// errors.Is(err, ErrAPIResponseErrorStatusCode) continues to work when err is an *APIError.
+func (e *APIError) Is(target error) bool {
+	if target == ErrAPIResponseErrorStatusCode {
+		return true
+	}
+	if target == ErrAPIResponseUnknownStatusCode {
+		return true
+	}
+	return false
+}

--- a/api/favorites.go
+++ b/api/favorites.go
@@ -19,7 +19,7 @@ type Favorite struct {
 func (c *Client) CreateFavorite(ctx context.Context, resourceID string) (*Favorite, error) {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "POST", "/favorites/resource/"+resourceID+".json", "v2", nil, nil)
 	if err != nil {
@@ -38,7 +38,7 @@ func (c *Client) CreateFavorite(ctx context.Context, resourceID string) (*Favori
 func (c *Client) DeleteFavorite(ctx context.Context, favoriteID string) error {
 	err := checkUUIDFormat(favoriteID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequest(ctx, "DELETE", "/favorites/"+favoriteID+".json", "v2", nil, nil)
 	if err != nil {

--- a/api/folders.go
+++ b/api/folders.go
@@ -86,7 +86,7 @@ func (c *Client) CreateFolder(ctx context.Context, folder Folder) (*Folder, erro
 func (c *Client) GetFolder(ctx context.Context, folderID string, opts *GetFolderOptions) (*Folder, error) {
 	err := checkUUIDFormat(folderID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "GET", "/folders/"+folderID+".json", "v2", nil, opts)
 	if err != nil {
@@ -105,7 +105,7 @@ func (c *Client) GetFolder(ctx context.Context, folderID string, opts *GetFolder
 func (c *Client) UpdateFolder(ctx context.Context, folderID string, folder Folder) (*Folder, error) {
 	err := checkUUIDFormat(folderID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "PUT", "/folders/"+folderID+".json", "v2", folder, nil)
 	if err != nil {
@@ -123,7 +123,7 @@ func (c *Client) UpdateFolder(ctx context.Context, folderID string, folder Folde
 func (c *Client) DeleteFolder(ctx context.Context, folderID string) error {
 	err := checkUUIDFormat(folderID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequest(ctx, "DELETE", "/folders/"+folderID+".json", "v2", nil, nil)
 	if err != nil {
@@ -136,7 +136,7 @@ func (c *Client) DeleteFolder(ctx context.Context, folderID string) error {
 func (c *Client) MoveFolder(ctx context.Context, folderID, folderParentID string) error {
 	err := checkUUIDFormat(folderID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequest(ctx, "PUT", "/move/folder/"+folderID+".json", "v2", Folder{
 		FolderParentID: folderParentID,

--- a/api/gpgkey.go
+++ b/api/gpgkey.go
@@ -48,7 +48,7 @@ func (c *Client) GetGPGKeys(ctx context.Context, opts *GetGPGKeysOptions) ([]GPG
 func (c *Client) GetGPGKey(ctx context.Context, gpgkeyID string) (*GPGKey, error) {
 	err := checkUUIDFormat(gpgkeyID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "GET", "/gpgkeys/"+gpgkeyID+".json", "v2", nil, nil)
 	if err != nil {

--- a/api/groups.go
+++ b/api/groups.go
@@ -128,7 +128,7 @@ func (c *Client) CreateGroup(ctx context.Context, group Group) (*Group, error) {
 func (c *Client) GetGroup(ctx context.Context, groupID string) (*Group, error) {
 	err := checkUUIDFormat(groupID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "GET", "/groups/"+groupID+".json", "v2", nil, nil)
 	if err != nil {
@@ -147,7 +147,7 @@ func (c *Client) GetGroup(ctx context.Context, groupID string) (*Group, error) {
 func (c *Client) UpdateGroup(ctx context.Context, groupID string, update GroupUpdate) (*Group, error) {
 	err := checkUUIDFormat(groupID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "PUT", "/groups/"+groupID+".json", "v2", update, nil)
 	if err != nil {
@@ -165,7 +165,7 @@ func (c *Client) UpdateGroup(ctx context.Context, groupID string, update GroupUp
 func (c *Client) UpdateGroupDryRun(ctx context.Context, groupID string, update GroupUpdate) (*UpdateGroupDryRunResult, error) {
 	err := checkUUIDFormat(groupID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "PUT", "/groups/"+groupID+"/dry-run.json", "v2", update, nil)
 	if err != nil {
@@ -183,7 +183,7 @@ func (c *Client) UpdateGroupDryRun(ctx context.Context, groupID string, update G
 func (c *Client) DeleteGroup(ctx context.Context, groupID string) error {
 	err := checkUUIDFormat(groupID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequest(ctx, "DELETE", "/groups/"+groupID+".json", "v2", nil, nil)
 	if err != nil {

--- a/api/metadata.go
+++ b/api/metadata.go
@@ -6,10 +6,10 @@ import (
 	"github.com/ProtonMail/gopenpgp/v3/crypto"
 )
 
-const PASSBOLT_OBJECT_TYPE_RESOURCE_METADATA = "PASSBOLT_RESOURCE_METADATA"
-const PASSBOLT_OBJECT_TYPE_SECRET_DATA = "PASSBOLT_SECRET_DATA"
+const PassboltObjectTypeResourceMetadata = "PASSBOLT_RESOURCE_METADATA"
+const PassboltObjectTypeSecretData = "PASSBOLT_SECRET_DATA"
 
-// ResourceMetadataTypeV5Default
+// ResourceMetadataTypeV5Default represents the metadata for a V5 default resource.
 type ResourceMetadataTypeV5Default struct {
 	ObjectType     string   `json:"object_type"`
 	ResourceTypeID string   `json:"resource_type_id,omitempty"`
@@ -19,7 +19,7 @@ type ResourceMetadataTypeV5Default struct {
 	Description    string   `json:"description,omitempty"`
 }
 
-// ResourceMetadataTypeV5DefaultWithTOTP
+// ResourceMetadataTypeV5DefaultWithTOTP represents the metadata for a V5 default resource with TOTP.
 type ResourceMetadataTypeV5DefaultWithTOTP struct {
 	ObjectType     string   `json:"object_type"`
 	ResourceTypeID string   `json:"resource_type_id,omitempty"`
@@ -29,7 +29,7 @@ type ResourceMetadataTypeV5DefaultWithTOTP struct {
 	Description    string   `json:"description,omitempty"`
 }
 
-// ResourceMetadataTypeV5PasswordString
+// ResourceMetadataTypeV5PasswordString represents the metadata for a V5 password string resource.
 type ResourceMetadataTypeV5PasswordString struct {
 	ObjectType     string   `json:"object_type"`
 	ResourceTypeID string   `json:"resource_type_id,omitempty"`
@@ -39,7 +39,7 @@ type ResourceMetadataTypeV5PasswordString struct {
 	Description    string   `json:"description,omitempty"`
 }
 
-// ResourceMetadataTypeV5TOTPStandalone
+// ResourceMetadataTypeV5TOTPStandalone represents the metadata for a V5 standalone TOTP resource.
 type ResourceMetadataTypeV5TOTPStandalone struct {
 	ObjectType     string   `json:"object_type"`
 	ResourceTypeID string   `json:"resource_type_id,omitempty"`
@@ -77,7 +77,7 @@ func (c *Client) DecryptMetadataWithKeyID(metadataKeyID string, metadataKey *cry
 	// or GetUserPrivateKeyCopy, so we can use it directly without additional copying.
 	metadata, newSessionKey, err := c.decryptMessageWithPrivateKeyDirect(metadataKey, armoredCiphertext)
 	if err != nil {
-		return "", fmt.Errorf("Decrypting Metadata: %w", err)
+		return "", fmt.Errorf("decrypting Metadata: %w", err)
 	}
 
 	// Cache the session key for future use (clone it to avoid Clear() corruption)
@@ -128,7 +128,7 @@ func (c *Client) DecryptMetadataWithResourceID(resourceID, metadataKeyID string,
 	// so we can use it directly without additional copying.
 	metadata, newSessionKey, err := c.decryptMessageWithPrivateKeyDirect(metadataKey, armoredCiphertext)
 	if err != nil {
-		return "", fmt.Errorf("Decrypting Metadata: %w", err)
+		return "", fmt.Errorf("decrypting Metadata: %w", err)
 	}
 
 	// Cache the session key by resource ID if available
@@ -149,7 +149,7 @@ func (c *Client) DecryptMetadataWithResourceID(resourceID, metadataKeyID string,
 func (c *Client) EncryptMetadata(metadataKey *crypto.Key, data string) (string, error) {
 	armoredCiphertext, err := c.EncryptMessageWithKey(metadataKey, data)
 	if err != nil {
-		return "", fmt.Errorf("Encrypting Metadata: %w", err)
+		return "", fmt.Errorf("encrypting Metadata: %w", err)
 	}
 
 	return armoredCiphertext, nil

--- a/api/metadata_implementation_test.go
+++ b/api/metadata_implementation_test.go
@@ -457,8 +457,8 @@ func TestGetResourceWithMetadata(t *testing.T) {
 		t.Error("Metadata missing object_type field")
 	}
 
-	if objectType != api.PASSBOLT_OBJECT_TYPE_RESOURCE_METADATA {
-		t.Errorf("Expected object_type %s, got %v", api.PASSBOLT_OBJECT_TYPE_RESOURCE_METADATA, objectType)
+	if objectType != api.PassboltObjectTypeResourceMetadata {
+		t.Errorf("Expected object_type %s, got %v", api.PassboltObjectTypeResourceMetadata, objectType)
 	}
 
 	// Verify the metadata contains the values we set

--- a/api/metadata_sessionkey.go
+++ b/api/metadata_sessionkey.go
@@ -70,7 +70,7 @@ func (c *Client) FetchAndCacheSessionKeys(ctx context.Context) (int, error) {
 	// Fetch the user's session keys row(s) from the server
 	sessionKeys, err := c.GetMetadataSessionKeys(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("Get Metadata Session Keys: %w", err)
+		return 0, fmt.Errorf("get Metadata Session Keys: %w", err)
 	}
 
 	if len(sessionKeys) == 0 {
@@ -165,7 +165,7 @@ func (c *Client) FetchAndCacheSessionKeys(ctx context.Context) (int, error) {
 func (c *Client) DeleteSessionKey(ctx context.Context, sessionKeyID string) error {
 	err := checkUUIDFormat(sessionKeyID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequestV5(ctx, "DELETE", "/metadata/session-keys/"+sessionKeyID+".json", nil, nil)
 	if err != nil {

--- a/api/metadata_settings.go
+++ b/api/metadata_settings.go
@@ -38,7 +38,7 @@ type MetadataTypeSettings struct {
 	AllowV4V5Downgrade         bool                   `json:"allow_v5_v4_downgrade"`
 }
 
-// MetadataTypeSettings Contains the Servers Settings about which Types to use
+// MetadataKeySettings contains the server settings about which metadata keys to use.
 type MetadataKeySettings struct {
 	AllowUsageOfPersonalKeys   bool `json:"allow_usage_of_personal_keys"`
 	AllowZeroKnowledgeKeyShare bool `json:"zero_knowledge_key_share"`

--- a/api/metadatakey.go
+++ b/api/metadatakey.go
@@ -78,12 +78,12 @@ type GetMetadataKeysOptions struct {
 	ContainMetadataPrivateKeys bool `url:"contain[metadata_private_keys],omitempty"`
 }
 
-// SetTrustedMetadatakeyFingerprint
+// SetTrustedMetadatakeyFingerprint sets the trusted metadata key fingerprint.
 func (c *Client) SetTrustedMetadatakeyFingerprint(fingerprint string, signTime time.Time) {
 	c.trustedMetadataKeyFingerprint = &fingerprint
 }
 
-// GetTrustedMetadatakeyFingerprint
+// GetTrustedMetadatakeyFingerprint returns the trusted metadata key fingerprint.
 func (c *Client) GetTrustedMetadatakeyFingerprint() *string {
 	return c.trustedMetadataKeyFingerprint
 }
@@ -111,16 +111,16 @@ func (c *Client) GetMetadataKey(ctx context.Context, personal bool) (string, Met
 	if personal && c.MetadataKeySettings().AllowUsageOfPersonalKeys {
 		key, err := c.GetUserPrivateKeyCopy()
 		if err != nil {
-			return "", "", nil, fmt.Errorf("Get User Private Key: %w", err)
+			return "", "", nil, fmt.Errorf("get User Private Key: %w", err)
 		}
 
 		me, err := c.GetMe(ctx)
 		if err != nil {
-			return "", "", nil, fmt.Errorf("Get User Me: %w", err)
+			return "", "", nil, fmt.Errorf("get User Me: %w", err)
 		}
 
 		if me.GPGKey == nil {
-			return "", "", nil, fmt.Errorf("User Me GPG Key nil")
+			return "", "", nil, fmt.Errorf("user Me GPG Key nil")
 		}
 
 		return me.GPGKey.ID, MetadataKeyTypeUserKey, key, nil
@@ -130,7 +130,7 @@ func (c *Client) GetMetadataKey(ctx context.Context, personal bool) (string, Met
 		ContainMetadataPrivateKeys: true,
 	})
 	if err != nil {
-		return "", "", nil, fmt.Errorf("Get Metadata Key: %w", err)
+		return "", "", nil, fmt.Errorf("get Metadata Key: %w", err)
 	}
 
 	// Get The Newest Metadata Key
@@ -145,41 +145,44 @@ func (c *Client) GetMetadataKey(ctx context.Context, personal bool) (string, Met
 	}
 
 	if privateMetadataKey == nil {
-		return "", "", nil, fmt.Errorf("No Metadata Private key for our user")
+		return "", "", nil, fmt.Errorf("no Metadata Private key for our user")
 	}
 
 	decPrivateMetadatakey, err := c.DecryptMessage(privateMetadataKey.Data)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("Decrypt Metadata Private Key Data: %w", err)
+		return "", "", nil, fmt.Errorf("decrypt Metadata Private Key Data: %w", err)
 	}
 
 	var data MetadataPrivateKeyData
 	err = json.Unmarshal([]byte(decPrivateMetadatakey), &data)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("Parse Metadata Private Key Data")
+		return "", "", nil, fmt.Errorf("parse Metadata Private Key Data")
 	}
 
 	metadataPrivateKeyObj, err := GetPrivateKeyFromArmor(data.ArmoredKey, []byte(data.Passphrase))
 	if err != nil {
-		return "", "", nil, fmt.Errorf("Get Metadata Private Key: %w", err)
+		return "", "", nil, fmt.Errorf("get Metadata Private Key: %w", err)
 	}
 
 	// Verify the key
 	if c.GetTrustedMetadatakeyFingerprint() == nil || metadataPrivateKeyObj.GetFingerprint() != *c.GetTrustedMetadatakeyFingerprint() {
 
 		if c.trustedMetadataKeySigntime != nil && !data.Signed.Time.After(*c.trustedMetadataKeySigntime) {
-			return "", "", nil, fmt.Errorf("New Metadata Key is older than the currently trusted one: %w", err)
+			return "", "", nil, fmt.Errorf("new Metadata Key is older than the currently trusted one: %w", err)
 		}
 
 		userPrivateKey, err := c.GetUserPrivateKeyCopy()
 		if err != nil {
-			return "", "", nil, fmt.Errorf("Get User Private Key Copy: %w", err)
+			return "", "", nil, fmt.Errorf("get User Private Key Copy: %w", err)
 		}
 
 		verify, err := c.pgp.Verify().VerificationKey(userPrivateKey).New()
+		if err != nil {
+			return "", "", nil, fmt.Errorf("creating verifier: %w", err)
+		}
 		verifyRes, err := verify.VerifyInline([]byte(privateMetadataKey.Data), crypto.Armor)
 		if err != nil {
-			return "", "", nil, fmt.Errorf("Verify User Metadata Private Key Signature: %w", err)
+			return "", "", nil, fmt.Errorf("verify User Metadata Private Key Signature: %w", err)
 		}
 
 		signedByFingerprint := hex.EncodeToString(verifyRes.SignedByFingerprint())
@@ -199,14 +202,14 @@ func (c *Client) GetMetadataKey(ctx context.Context, personal bool) (string, Met
 		if c.MetadataKeyUpdatedCallback == nil {
 			// Fail if there is a key pinned but the signature check failed
 			if c.trustedMetadataKeyFingerprint != nil || !trusted {
-				return "", "", nil, fmt.Errorf("Metadata Key has changed, The Callback is nil, There is a Key Pinned but the new one is not trusted")
+				return "", "", nil, fmt.Errorf("metadata Key has changed, The Callback is nil, There is a Key Pinned but the new one is not trusted")
 			}
 			c.log("No Callback is defined, No Metadata key is pinned and the Signature is by our Private key, automatically trusting")
 
 		} else {
 			err = c.MetadataKeyUpdatedCallback(ctx, trusted, metadataPrivateKeyObj.GetFingerprint(), data.Signed.Time)
 			if err != nil {
-				return "", "", nil, fmt.Errorf("Metadata Key has changed, Callback: %w", err)
+				return "", "", nil, fmt.Errorf("metadata Key has changed, Callback: %w", err)
 			}
 		}
 
@@ -217,13 +220,13 @@ func (c *Client) GetMetadataKey(ctx context.Context, personal bool) (string, Met
 	return metadatakey.ID, MetadataKeyTypeSharedKey, metadataPrivateKeyObj, nil
 }
 
-// GetMetadataKeyById is for fetching a specific metadatakey if needed for Decryption, these are not verified
-func (c *Client) GetMetadataKeyById(ctx context.Context, id string) (*crypto.Key, error) {
+// GetMetadataKeyByID is for fetching a specific metadatakey if needed for decryption, these are not verified.
+func (c *Client) GetMetadataKeyByID(ctx context.Context, id string) (*crypto.Key, error) {
 	keys, err := c.GetMetadataKeys(ctx, &GetMetadataKeysOptions{
 		ContainMetadataPrivateKeys: true,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Get Metadata Key: %w", err)
+		return nil, fmt.Errorf("get Metadata Key: %w", err)
 	}
 	var key *MetadataKey
 	for _, k := range keys {
@@ -234,36 +237,36 @@ func (c *Client) GetMetadataKeyById(ctx context.Context, id string) (*crypto.Key
 	}
 
 	if key == nil {
-		return nil, fmt.Errorf("Metadata key not found: %v", id)
+		return nil, fmt.Errorf("metadata key not found: %v", id)
 	}
 
 	if len(key.MetadataPrivateKeys) == 0 {
-		return nil, fmt.Errorf("No Metadata Private key for our user")
+		return nil, fmt.Errorf("no Metadata Private key for our user")
 	}
 
 	if len(key.MetadataPrivateKeys) > 1 {
-		return nil, fmt.Errorf("More than 1 metadata Private key for our user")
+		return nil, fmt.Errorf("more than 1 metadata Private key for our user")
 	}
 
-	var privMetdata MetadataPrivateKey = key.MetadataPrivateKeys[0]
+	var privMetdata = key.MetadataPrivateKeys[0]
 	if *privMetdata.UserID != c.GetUserID() {
-		return nil, fmt.Errorf("MetadataPrivateKey is not for our user id: %v", privMetdata.UserID)
+		return nil, fmt.Errorf("metadataPrivateKey is not for our user id: %v", privMetdata.UserID)
 	}
 
 	decPrivMetadatakey, err := c.DecryptMessage(privMetdata.Data)
 	if err != nil {
-		return nil, fmt.Errorf("Decrypt Metadata Private Key Data: %w", err)
+		return nil, fmt.Errorf("decrypt Metadata Private Key Data: %w", err)
 	}
 
 	var data MetadataPrivateKeyData
 	err = json.Unmarshal([]byte(decPrivMetadatakey), &data)
 	if err != nil {
-		return nil, fmt.Errorf("Parse Metadata Private Key Data")
+		return nil, fmt.Errorf("parse Metadata Private Key Data")
 	}
 
 	metadataPrivateKeyObj, err := GetPrivateKeyFromArmor(data.ArmoredKey, []byte(data.Passphrase))
 	if err != nil {
-		return nil, fmt.Errorf("Get Metadata Private Key: %w", err)
+		return nil, fmt.Errorf("get Metadata Private Key: %w", err)
 	}
 
 	return metadataPrivateKeyObj, nil

--- a/api/misc.go
+++ b/api/misc.go
@@ -36,7 +36,7 @@ func checkAuthTokenFormat(authToken string) error {
 
 func checkUUIDFormat(data string) error {
 	if !isUUID.MatchString(data) {
-		return fmt.Errorf("uUID is not in the valid format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+		return ErrInvalidUUID
 	}
 	return nil
 }

--- a/api/misc.go
+++ b/api/misc.go
@@ -2,52 +2,41 @@ package api
 
 import (
 	"fmt"
-	"math/rand"
 	"regexp"
 	"strconv"
 	"strings"
 )
 
-const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
 var isUUID = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
-
-func randStringBytesRmndr(length int) string {
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
-	}
-	return string(b)
-}
 
 func checkAuthTokenFormat(authToken string) error {
 	splitAuthToken := strings.Split(authToken, "|")
 	if len(splitAuthToken) != 4 {
-		return fmt.Errorf("Auth Token Has Wrong amount of Fields")
+		return fmt.Errorf("auth Token Has Wrong amount of Fields")
 	}
 
 	if splitAuthToken[0] != splitAuthToken[3] {
-		return fmt.Errorf("Auth Token Version Fields Don't match")
+		return fmt.Errorf("auth Token Version Fields Don't match")
 	}
 
 	if !strings.HasPrefix(splitAuthToken[0], "gpgauth") {
-		return fmt.Errorf("Auth Token Version does not start with 'gpgauth'")
+		return fmt.Errorf("auth Token Version does not start with 'gpgauth'")
 	}
 
 	length, err := strconv.Atoi(splitAuthToken[1])
 	if err != nil {
-		return fmt.Errorf("Cannot Convert Auth Token Length Field to int: %w", err)
+		return fmt.Errorf("cannot Convert Auth Token Length Field to int: %w", err)
 	}
 
 	if len(splitAuthToken[2]) != length {
-		return fmt.Errorf("Auth Token Data Length does not Match Length Field")
+		return fmt.Errorf("auth Token Data Length does not Match Length Field")
 	}
 	return nil
 }
 
 func checkUUIDFormat(data string) error {
 	if !isUUID.MatchString(data) {
-		return fmt.Errorf("UUID is not in the valid format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+		return fmt.Errorf("uUID is not in the valid format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
 	}
 	return nil
 }

--- a/api/permissions.go
+++ b/api/permissions.go
@@ -24,7 +24,7 @@ type Permission struct {
 func (c *Client) GetResourcePermissions(ctx context.Context, resourceID string) ([]Permission, error) {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "GET", "/permissions/resource/"+resourceID+".json", "v2", nil, nil)
 	if err != nil {

--- a/api/resource_types.go
+++ b/api/resource_types.go
@@ -44,7 +44,7 @@ func (c *Client) GetResourceTypes(ctx context.Context, opts *GetResourceTypesOpt
 func (c *Client) GetResourceType(ctx context.Context, typeID string) (*ResourceType, error) {
 	err := checkUUIDFormat(typeID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "GET", "/resource-types/"+typeID+".json", "v2", nil, nil)
 	if err != nil {

--- a/api/resources.go
+++ b/api/resources.go
@@ -102,7 +102,7 @@ func (c *Client) CreateResource(ctx context.Context, resource Resource) (*Resour
 func (c *Client) GetResource(ctx context.Context, resourceID string) (*Resource, error) {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "GET", "/resources/"+resourceID+".json", "v2", nil, nil)
 	if err != nil {
@@ -121,7 +121,7 @@ func (c *Client) GetResource(ctx context.Context, resourceID string) (*Resource,
 func (c *Client) UpdateResource(ctx context.Context, resourceID string, resource Resource) (*Resource, error) {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 
 	msg, err := c.DoCustomRequest(ctx, "PUT", "/resources/"+resourceID+".json", "v2", resource, nil)
@@ -140,7 +140,7 @@ func (c *Client) UpdateResource(ctx context.Context, resourceID string, resource
 func (c *Client) DeleteResource(ctx context.Context, resourceID string) error {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequest(ctx, "DELETE", "/resources/"+resourceID+".json", "v2", nil, nil)
 	if err != nil {
@@ -153,7 +153,7 @@ func (c *Client) DeleteResource(ctx context.Context, resourceID string) error {
 func (c *Client) MoveResource(ctx context.Context, resourceID, folderParentID string) error {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequest(ctx, "PUT", "/move/resource/"+resourceID+".json", "v2", Resource{
 		FolderParentID: folderParentID,

--- a/api/schema.go
+++ b/api/schema.go
@@ -2,7 +2,7 @@ package api
 
 import "encoding/json"
 
-// Fallback Schema, Only to be used if we encounter a Broken Server (v5.0), Not API Stable!
+// ResourceSchemas is a fallback schema, only to be used if we encounter a broken server (v5.0). Not API stable!
 var ResourceSchemas = map[string]json.RawMessage{
 	"v5-default": json.RawMessage(`
 {

--- a/api/secrets.go
+++ b/api/secrets.go
@@ -41,7 +41,7 @@ type SecretDataTypePasswordDescriptionTOTP struct {
 	TOTP        SecretDataTOTP `json:"totp"`
 }
 
-// SecretDataTypeV5Default
+// SecretDataTypeV5Default represents the secret data for a V5 default resource.
 type SecretDataTypeV5Default struct {
 	ObjectType     string `json:"object_type"`
 	ResourceTypeID string `json:"resource_type_id,omitempty"`
@@ -49,7 +49,7 @@ type SecretDataTypeV5Default struct {
 	Description    string `json:"description,omitempty"`
 }
 
-// SecretDataTypeV5DefaultWithTOTP
+// SecretDataTypeV5DefaultWithTOTP represents the secret data for a V5 default resource with TOTP.
 type SecretDataTypeV5DefaultWithTOTP struct {
 	ObjectType     string         `json:"object_type"`
 	ResourceTypeID string         `json:"resource_type_id,omitempty"`
@@ -58,10 +58,10 @@ type SecretDataTypeV5DefaultWithTOTP struct {
 	TOTP           SecretDataTOTP `json:"totp"`
 }
 
-// SecretDataTypeV5PasswordString, is just the Password directly
+// SecretDataTypeV5PasswordString is just the password directly.
 type SecretDataTypeV5PasswordString string
 
-// SecretDataTypeV5TOTPStandalone
+// SecretDataTypeV5TOTPStandalone represents the secret data for a V5 standalone TOTP resource.
 type SecretDataTypeV5TOTPStandalone struct {
 	ObjectType     string         `json:"object_type"`
 	ResourceTypeID string         `json:"resource_type_id,omitempty"`
@@ -72,7 +72,7 @@ type SecretDataTypeV5TOTPStandalone struct {
 func (c *Client) GetSecret(ctx context.Context, resourceID string) (*Secret, error) {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "GET", "/secrets/resource/"+resourceID+".json", "v2", nil, nil)
 	if err != nil {

--- a/api/setup.go
+++ b/api/setup.go
@@ -24,11 +24,11 @@ type SetupCompleteRequest struct {
 func (c *Client) SetupInstall(ctx context.Context, userID, token string) (*SetupInstallResponse, error) {
 	err := checkUUIDFormat(userID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	err = checkUUIDFormat(token)
 	if err != nil {
-		return nil, fmt.Errorf("Checking Token format: %w", err)
+		return nil, fmt.Errorf("checking Token format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "GET", "/setup/install/"+userID+"/"+token+".json", "v2", nil, nil)
 	if err != nil {
@@ -47,7 +47,7 @@ func (c *Client) SetupInstall(ctx context.Context, userID, token string) (*Setup
 func (c *Client) SetupComplete(ctx context.Context, userID string, request SetupCompleteRequest) error {
 	err := checkUUIDFormat(userID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequest(ctx, "POST", "/setup/complete/"+userID+".json", "v2", request, nil)
 	if err != nil {

--- a/api/share.go
+++ b/api/share.go
@@ -89,7 +89,7 @@ func (c *Client) SearchAROs(ctx context.Context, opts SearchAROsOptions) ([]ARO,
 func (c *Client) ShareResource(ctx context.Context, resourceID string, shareRequest ResourceShareRequest) error {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequest(ctx, "PUT", "/share/resource/"+resourceID+".json", "v2", shareRequest, nil)
 	if err != nil {
@@ -103,7 +103,7 @@ func (c *Client) ShareResource(ctx context.Context, resourceID string, shareRequ
 func (c *Client) ShareFolder(ctx context.Context, folderID string, permissions []Permission) error {
 	err := checkUUIDFormat(folderID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	f := Folder{Permissions: permissions}
 	_, err = c.DoCustomRequest(ctx, "PUT", "/share/folder/"+folderID+".json", "v2", f, nil)
@@ -118,7 +118,7 @@ func (c *Client) ShareFolder(ctx context.Context, folderID string, permissions [
 func (c *Client) SimulateShareResource(ctx context.Context, resourceID string, shareRequest ResourceShareRequest) (*ResourceShareSimulationResult, error) {
 	err := checkUUIDFormat(resourceID)
 	if err != nil {
-		return nil, fmt.Errorf("Checking ID format: %w", err)
+		return nil, fmt.Errorf("checking ID format: %w", err)
 	}
 	msg, err := c.DoCustomRequest(ctx, "POST", "/share/simulate/resource/"+resourceID+".json", "v2", shareRequest, nil)
 	if err != nil {

--- a/api/users.go
+++ b/api/users.go
@@ -35,10 +35,10 @@ type User struct {
 
 // Profile is a Profile
 type Profile struct {
-	ID        string `json:"id,omitempty"`
-	UserID    string `json:"user_id,omitempty"`
-	FirstName string `json:"first_name,omitempty"`
-	LastName  string `json:"last_name,omitempty"`
+	ID        string  `json:"id,omitempty"`
+	UserID    string  `json:"user_id,omitempty"`
+	FirstName string  `json:"first_name,omitempty"`
+	LastName  string  `json:"last_name,omitempty"`
 	Created   *Time   `json:"created,omitempty"`
 	Modified  *Time   `json:"modified,omitempty"`
 	Avatar    *Avatar `json:"avatar,omitempty"`
@@ -95,7 +95,7 @@ func (c *Client) GetUser(ctx context.Context, userID string) (*User, error) {
 	if userID != "me" {
 		err := checkUUIDFormat(userID)
 		if err != nil {
-			return nil, fmt.Errorf("Checking ID format: %w", err)
+			return nil, fmt.Errorf("checking ID format: %w", err)
 		}
 	}
 	msg, err := c.DoCustomRequest(ctx, "GET", "/users/"+userID+".json", "v2", nil, nil)
@@ -116,7 +116,7 @@ func (c *Client) UpdateUser(ctx context.Context, userID string, user User) (*Use
 	if userID != "me" {
 		err := checkUUIDFormat(userID)
 		if err != nil {
-			return nil, fmt.Errorf("Checking ID format: %w", err)
+			return nil, fmt.Errorf("checking ID format: %w", err)
 		}
 	}
 	msg, err := c.DoCustomRequest(ctx, "PUT", "/users/"+userID+".json", "v2", user, nil)
@@ -136,7 +136,7 @@ func (c *Client) DeleteUser(ctx context.Context, userID string) error {
 	if userID != "me" {
 		err := checkUUIDFormat(userID)
 		if err != nil {
-			return fmt.Errorf("Checking ID format: %w", err)
+			return fmt.Errorf("checking ID format: %w", err)
 		}
 	}
 	_, err := c.DoCustomRequest(ctx, "DELETE", "/users/"+userID+".json", "v2", nil, nil)
@@ -150,7 +150,7 @@ func (c *Client) DeleteUser(ctx context.Context, userID string) error {
 func (c *Client) DeleteUserDryrun(ctx context.Context, userID string) error {
 	err := checkUUIDFormat(userID)
 	if err != nil {
-		return fmt.Errorf("Checking ID format: %w", err)
+		return fmt.Errorf("checking ID format: %w", err)
 	}
 	_, err = c.DoCustomRequest(ctx, "DELETE", "/users/"+userID+"/dry-run.json", "v2", nil, nil)
 	if err != nil {

--- a/api/verify.go
+++ b/api/verify.go
@@ -23,20 +23,20 @@ type GPGVerify struct {
 func (c *Client) SetupServerVerification(ctx context.Context) (string, string, error) {
 	serverKey, _, err := c.GetPublicKey(ctx)
 	if err != nil {
-		return "", "", fmt.Errorf("Getting Server Key: %w", err)
+		return "", "", fmt.Errorf("getting Server Key: %w", err)
 	}
 	uuid, err := uuid.NewRandom()
 	if err != nil {
-		return "", "", fmt.Errorf("Generating UUID: %w", err)
+		return "", "", fmt.Errorf("generating UUID: %w", err)
 	}
 	token := "gpgauthv1.3.0|36|" + uuid.String() + "|gpgauthv1.3.0"
 	encToken, err := c.EncryptMessageWithPublicKey(serverKey, token)
 	if err != nil {
-		return "", "", fmt.Errorf("Encrypting Challenge: %w", err)
+		return "", "", fmt.Errorf("encrypting Challenge: %w", err)
 	}
 	err = c.VerifyServer(ctx, token, encToken)
 	if err != nil {
-		return "", "", fmt.Errorf("Initial Verification: %w", err)
+		return "", "", fmt.Errorf("initial Verification: %w", err)
 	}
 	return token, encToken, err
 }
@@ -56,11 +56,11 @@ func (c *Client) VerifyServer(ctx context.Context, token, encToken string) error
 	}
 	raw, _, err := c.DoCustomRequestAndReturnRawResponse(ctx, "POST", "/auth/verify.json", "v2", data, nil)
 	if err != nil && !strings.Contains(err.Error(), "The authentication failed.") {
-		return fmt.Errorf("Sending Verification Challenge: %w", err)
+		return fmt.Errorf("sending Verification Challenge: %w", err)
 	}
 
 	if raw.Header.Get("X-GPGAuth-Verify-Response") != token {
-		return fmt.Errorf("Server Response did not Match Saved Token")
+		return fmt.Errorf("server Response did not Match Saved Token")
 	}
 	return nil
 }

--- a/helper/doc.go
+++ b/helper/doc.go
@@ -1,0 +1,2 @@
+// Package helper provides high-level operations for the Passbolt API.
+package helper

--- a/helper/errors.go
+++ b/helper/errors.go
@@ -5,3 +5,16 @@ import "errors"
 // ErrUnsupportedResourceType is returned when a resource has an unknown resource type slug
 // that cannot be decoded by the helper functions.
 var ErrUnsupportedResourceType = errors.New("unsupported resource type")
+
+var (
+	// Resource creation errors
+	ErrV5CreationDisabled       = errors.New("creation of V5 passwords is disabled on this server")
+	ErrV4CreationDisabled       = errors.New("creation of V4 passwords is disabled on this server")
+	ErrResourceTypeSlugNotFound = errors.New("cannot find resource type")
+	ErrPasswordTooLong          = errors.New("password exceeds maximum length")
+
+	// Lookup errors
+	ErrKeyNotFound        = errors.New("cannot find key for user")
+	ErrMembershipNotFound = errors.New("cannot find membership for user")
+	ErrSecretNotFound     = errors.New("cannot find secret for resource")
+)

--- a/helper/folder.go
+++ b/helper/folder.go
@@ -14,7 +14,7 @@ func CreateFolder(ctx context.Context, c *api.Client, folderParentID, name strin
 		FolderParentID: folderParentID,
 	})
 	if err != nil {
-		return "", fmt.Errorf("Creating Folder: %w", err)
+		return "", fmt.Errorf("creating Folder: %w", err)
 	}
 	return f.ID, nil
 }
@@ -23,7 +23,7 @@ func CreateFolder(ctx context.Context, c *api.Client, folderParentID, name strin
 func GetFolder(ctx context.Context, c *api.Client, folderID string) (string, string, error) {
 	f, err := c.GetFolder(ctx, folderID, nil)
 	if err != nil {
-		return "", "", fmt.Errorf("Getting Folder: %w", err)
+		return "", "", fmt.Errorf("getting Folder: %w", err)
 	}
 	return f.FolderParentID, f.Name, nil
 }
@@ -32,7 +32,7 @@ func GetFolder(ctx context.Context, c *api.Client, folderID string) (string, str
 func UpdateFolder(ctx context.Context, c *api.Client, folderID, name string) error {
 	_, err := c.UpdateFolder(ctx, folderID, api.Folder{Name: name})
 	if err != nil {
-		return fmt.Errorf("Updating Folder: %w", err)
+		return fmt.Errorf("updating Folder: %w", err)
 	}
 	return err
 }
@@ -41,7 +41,7 @@ func UpdateFolder(ctx context.Context, c *api.Client, folderID, name string) err
 func DeleteFolder(ctx context.Context, c *api.Client, folderID string) error {
 	err := c.DeleteFolder(ctx, folderID)
 	if err != nil {
-		return fmt.Errorf("Deleting Folder: %w", err)
+		return fmt.Errorf("deleting Folder: %w", err)
 	}
 	return nil
 }
@@ -50,7 +50,7 @@ func DeleteFolder(ctx context.Context, c *api.Client, folderID string) error {
 func MoveFolder(ctx context.Context, c *api.Client, folderID, folderParentID string) error {
 	err := c.MoveFolder(ctx, folderID, folderParentID)
 	if err != nil {
-		return fmt.Errorf("Moving Folder: %w", err)
+		return fmt.Errorf("moving Folder: %w", err)
 	}
 	return nil
 }

--- a/helper/group.go
+++ b/helper/group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ProtonMail/gopenpgp/v3/crypto"
 	"github.com/passbolt/go-passbolt/api"
 )
 
@@ -28,7 +29,7 @@ func CreateGroup(ctx context.Context, c *api.Client, name string, operations []G
 	memberships := []api.GroupMembership{}
 	for _, o := range operations {
 		if o.Delete {
-			return "", fmt.Errorf("Cannot Delete Membership during Group Creation")
+			return "", fmt.Errorf("cannot Delete Membership during Group Creation")
 		}
 		memberships = append(memberships, api.GroupMembership{
 			UserID:  o.UserID,
@@ -40,7 +41,7 @@ func CreateGroup(ctx context.Context, c *api.Client, name string, operations []G
 		GroupUsers: memberships,
 	})
 	if err != nil {
-		return "", fmt.Errorf("Creating Group: %w", err)
+		return "", fmt.Errorf("creating Group: %w", err)
 	}
 	return group.ID, nil
 }
@@ -54,7 +55,7 @@ func GetGroup(ctx context.Context, c *api.Client, groupID string) (string, []Gro
 		ContainGroupsUsersUserProfile: true,
 	})
 	if err != nil {
-		return "", nil, fmt.Errorf("Getting Groups: %w", err)
+		return "", nil, fmt.Errorf("getting Groups: %w", err)
 	}
 
 	for _, g := range groups {
@@ -72,7 +73,7 @@ func GetGroup(ctx context.Context, c *api.Client, groupID string) (string, []Gro
 			return g.Name, memberships, nil
 		}
 	}
-	return "", nil, fmt.Errorf("Cannot Find Group in API Response")
+	return "", nil, fmt.Errorf("cannot Find Group in API Response")
 }
 
 // UpdateGroup Updates a Groups Name and Memberships
@@ -82,7 +83,7 @@ func UpdateGroup(ctx context.Context, c *api.Client, groupID, name string, opera
 		ContainGroupsUsers: true,
 	})
 	if err != nil {
-		return fmt.Errorf("Getting Groups: %w", err)
+		return fmt.Errorf("getting Groups: %w", err)
 	}
 
 	var currentMemberships []api.GroupMembership
@@ -95,7 +96,7 @@ func UpdateGroup(ctx context.Context, c *api.Client, groupID, name string, opera
 		}
 	}
 	if currentMemberships == nil {
-		return fmt.Errorf("Cannot Find Group with ID %v", groupID)
+		return fmt.Errorf("cannot Find Group with ID %v", groupID)
 	}
 
 	request := api.GroupUpdate{
@@ -114,7 +115,7 @@ func UpdateGroup(ctx context.Context, c *api.Client, groupID, name string, opera
 		if err != nil {
 			// Membership does not Exist so we can only create a new one
 			if operation.Delete {
-				return fmt.Errorf("Cannot Delete User %v as it has no membership", operation.UserID)
+				return fmt.Errorf("cannot Delete User %v as it has no membership", operation.UserID)
 			}
 			request.GroupChanges = append(request.GroupChanges, api.GroupMembership{
 				UserID:  operation.UserID,
@@ -123,7 +124,7 @@ func UpdateGroup(ctx context.Context, c *api.Client, groupID, name string, opera
 		} else {
 			// Membership Exists so we can modify or delete it
 			if !operation.Delete && membership.IsAdmin == operation.IsGroupManager {
-				return fmt.Errorf("Membership for User %v already Exists with Same Role", operation.UserID)
+				return fmt.Errorf("membership for User %v already Exists with Same Role", operation.UserID)
 			}
 			request.GroupChanges = append(request.GroupChanges, api.GroupMembership{
 				ID:      membership.ID,
@@ -135,7 +136,7 @@ func UpdateGroup(ctx context.Context, c *api.Client, groupID, name string, opera
 
 	dryrun, err := c.UpdateGroupDryRun(ctx, groupID, request)
 	if err != nil {
-		return fmt.Errorf("Update Group Dryrun: %w", err)
+		return fmt.Errorf("update Group Dryrun: %w", err)
 	}
 
 	var users []api.User
@@ -143,7 +144,7 @@ func UpdateGroup(ctx context.Context, c *api.Client, groupID, name string, opera
 	if len(dryrun.DryRun.SecretsNeeded) != 0 {
 		users, err = c.GetUsers(ctx, &api.GetUsersOptions{})
 		if err != nil {
-			return fmt.Errorf("Getting Users: %w", err)
+			return fmt.Errorf("getting Users: %w", err)
 		}
 	}
 
@@ -160,12 +161,12 @@ func UpdateGroup(ctx context.Context, c *api.Client, groupID, name string, opera
 		if decryptedSecretCache[missingSecret.ResourceID] == "" {
 			secret, err := getSecretByResourceID(secrets, missingSecret.ResourceID)
 			if err != nil {
-				return fmt.Errorf("Get Secret from Dryrun Response: %w", err)
+				return fmt.Errorf("get Secret from Dryrun Response: %w", err)
 			}
 
 			msg, err := c.DecryptMessage(secret.Data)
 			if err != nil {
-				return fmt.Errorf("Decrypting Secret: %w", err)
+				return fmt.Errorf("decrypting Secret: %w", err)
 			}
 
 			decryptedSecretCache[missingSecret.ResourceID] = msg
@@ -173,12 +174,17 @@ func UpdateGroup(ctx context.Context, c *api.Client, groupID, name string, opera
 
 		pubkey, err := getPublicKeyByUserID(missingSecret.UserID, users)
 		if err != nil {
-			return fmt.Errorf("Get pubkey for User: %w", err)
+			return fmt.Errorf("get pubkey for User: %w", err)
 		}
 
-		newSecretData, err := c.EncryptMessageWithPublicKey(pubkey, decryptedSecretCache[missingSecret.ResourceID])
+		publicKey, err := crypto.NewKeyFromArmored(pubkey)
 		if err != nil {
-			return fmt.Errorf("Encrypting Secret: %w", err)
+			return fmt.Errorf("parsing public key for user %v: %w", missingSecret.UserID, err)
+		}
+
+		newSecretData, err := c.EncryptMessageWithKey(publicKey, decryptedSecretCache[missingSecret.ResourceID])
+		if err != nil {
+			return fmt.Errorf("encrypting Secret: %w", err)
 		}
 		request.Secrets = append(request.Secrets, api.Secret{
 			UserID:     missingSecret.UserID,
@@ -189,7 +195,7 @@ func UpdateGroup(ctx context.Context, c *api.Client, groupID, name string, opera
 
 	_, err = c.UpdateGroup(ctx, groupID, request)
 	if err != nil {
-		return fmt.Errorf("Updating Group: %w", err)
+		return fmt.Errorf("updating Group: %w", err)
 	}
 	return nil
 }
@@ -198,7 +204,7 @@ func UpdateGroup(ctx context.Context, c *api.Client, groupID, name string, opera
 func DeleteGroup(ctx context.Context, c *api.Client, groupID string) error {
 	err := c.DeleteGroup(ctx, groupID)
 	if err != nil {
-		return fmt.Errorf("Deleting Group: %w", err)
+		return fmt.Errorf("deleting Group: %w", err)
 	}
 	return nil
 }

--- a/helper/metadata.go
+++ b/helper/metadata.go
@@ -25,7 +25,7 @@ func GetResourceMetadata(ctx context.Context, c *api.Client, resource *api.Resou
 		if err == nil {
 			err = validateMetadata(rType, string(decMetadata))
 			if err != nil {
-				return "", fmt.Errorf("Validate Metadata: %w", err)
+				return "", fmt.Errorf("validate Metadata: %w", err)
 			}
 			return decMetadata, nil
 		}
@@ -38,7 +38,7 @@ func GetResourceMetadata(ctx context.Context, c *api.Client, resource *api.Resou
 	if resource.MetadataKeyType == api.MetadataKeyTypeUserKey {
 		tmp, err := c.GetUserPrivateKeyCopy()
 		if err != nil {
-			return "", fmt.Errorf("Get Private Key Copy: %w", err)
+			return "", fmt.Errorf("get Private Key Copy: %w", err)
 		}
 		metadatakey = tmp
 		// Use user key fingerprint as cache key to enable session key caching
@@ -48,7 +48,7 @@ func GetResourceMetadata(ctx context.Context, c *api.Client, resource *api.Resou
 		metadataKeyID = resource.MetadataKeyID
 		key, err := c.GetDecryptedMetadataKeyCached(ctx, metadataKeyID)
 		if err != nil {
-			return "", fmt.Errorf("Get Metadata Key by ID: %w", err)
+			return "", fmt.Errorf("get Metadata Key by ID: %w", err)
 		}
 		metadatakey = key
 	}
@@ -57,12 +57,12 @@ func GetResourceMetadata(ctx context.Context, c *api.Client, resource *api.Resou
 	// This provides optimal performance when PreFetchCaches() has been called during login
 	decMetadata, err := c.DecryptMetadataWithResourceID(resource.ID, metadataKeyID, metadatakey, resource.Metadata)
 	if err != nil {
-		return "", fmt.Errorf("Decrypt Metadata: %w", err)
+		return "", fmt.Errorf("decrypt Metadata: %w", err)
 	}
 
 	err = validateMetadata(rType, string(decMetadata))
 	if err != nil {
-		return "", fmt.Errorf("Validate Metadata: %w", err)
+		return "", fmt.Errorf("validate Metadata: %w", err)
 	}
 
 	return decMetadata, nil
@@ -94,15 +94,15 @@ func validateMetadata(rType *api.ResourceType, metadata string) error {
 				var tmp string
 				err = json.Unmarshal([]byte(definition), &tmp)
 				if err != nil {
-					return fmt.Errorf("Workaround Unmarshal Json Schema String: %w", err)
+					return fmt.Errorf("workaround Unmarshal Json Schema String: %w", err)
 				}
 
 				err = json.Unmarshal([]byte(tmp), &schemaDefinition)
 				if err != nil {
-					return fmt.Errorf("Workaround Unmarshal Json Schema: %w", err)
+					return fmt.Errorf("workaround Unmarshal Json Schema: %w", err)
 				}
 			} else {
-				return fmt.Errorf("Unmarshal Json Schema: %w", err)
+				return fmt.Errorf("unmarshal Json Schema: %w", err)
 			}
 		}
 
@@ -110,12 +110,12 @@ func validateMetadata(rType *api.ResourceType, metadata string) error {
 
 		err = comp.AddResource("metadata.json", schemaDefinition.Resource)
 		if err != nil {
-			return fmt.Errorf("Adding Json Schema: %w", err)
+			return fmt.Errorf("adding Json Schema: %w", err)
 		}
 
 		schema, err = comp.Compile("metadata.json")
 		if err != nil {
-			return fmt.Errorf("Compiling Json Schema: %w", err)
+			return fmt.Errorf("compiling Json Schema: %w", err)
 		}
 
 		// Cache the compiled schema
@@ -127,12 +127,12 @@ func validateMetadata(rType *api.ResourceType, metadata string) error {
 	var parsedMetadata map[string]any
 	err := json.Unmarshal([]byte(metadata), &parsedMetadata)
 	if err != nil {
-		return fmt.Errorf("Unmarshal Secret: %w", err)
+		return fmt.Errorf("unmarshal Secret: %w", err)
 	}
 
 	err = schema.Validate(parsedMetadata)
 	if err != nil {
-		return fmt.Errorf("Validating Metadata with Schema: %w", err)
+		return fmt.Errorf("validating Metadata with Schema: %w", err)
 	}
 	return nil
 }

--- a/helper/metadata.go
+++ b/helper/metadata.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -89,8 +90,9 @@ func validateMetadata(rType *api.ResourceType, metadata string) error {
 
 		err := json.Unmarshal([]byte(definition), &schemaDefinition)
 		if err != nil {
-			// Workaround for inconsistant API Responses where sometime the Schema is embedded directly and sometimes it's escaped as a string
-			if err.Error() == "json: cannot unmarshal string into Go value of type api.ResourceTypeSchema" {
+			// Workaround for inconsistent API Responses where sometimes the Schema is embedded directly and sometimes it's escaped as a string
+			var unmarshalErr *json.UnmarshalTypeError
+			if errors.As(err, &unmarshalErr) {
 				var tmp string
 				err = json.Unmarshal([]byte(definition), &tmp)
 				if err != nil {

--- a/helper/mfa.go
+++ b/helper/mfa.go
@@ -34,7 +34,8 @@ func AddMFACallbackTOTP(c *api.Client, retrys uint, retryDelay, offset time.Dura
 			var raw *http.Response
 			raw, _, err = c.DoCustomRequestAndReturnRawResponseV5(ctx, "POST", "mfa/verify/totp.json", req, nil)
 			if err != nil {
-				if errors.Unwrap(err) != api.ErrAPIResponseErrorStatusCode {
+				var apiErr *api.APIError
+				if !errors.As(err, &apiErr) {
 					return http.Cookie{}, fmt.Errorf("doing MFA Challenge Response: %w", err)
 				}
 				// MFA failed, so lets wait just let the loop try again

--- a/helper/mfa.go
+++ b/helper/mfa.go
@@ -17,25 +17,25 @@ func AddMFACallbackTOTP(c *api.Client, retrys uint, retryDelay, offset time.Dura
 		challenge := api.MFAChallenge{}
 		err := json.Unmarshal(res.Body, &challenge)
 		if err != nil {
-			return http.Cookie{}, fmt.Errorf("Parsing MFA Challenge")
+			return http.Cookie{}, fmt.Errorf("parsing MFA Challenge")
 		}
 		if challenge.Provider.TOTP == "" {
-			return http.Cookie{}, fmt.Errorf("Server Provided no TOTP Provider")
+			return http.Cookie{}, fmt.Errorf("server Provided no TOTP Provider")
 		}
 		for i := uint(0); i < retrys+1; i++ {
 			var code string
 			code, err = GenerateOTPCode(token, time.Now().Add(offset))
 			if err != nil {
-				return http.Cookie{}, fmt.Errorf("Error Generating MFA Code: %w", err)
+				return http.Cookie{}, fmt.Errorf("error Generating MFA Code: %w", err)
 			}
 			req := api.MFAChallengeResponse{
 				TOTP: code,
 			}
 			var raw *http.Response
-			raw, _, err = c.DoCustomRequestAndReturnRawResponse(ctx, "POST", "mfa/verify/totp.json", "v2", req, nil)
+			raw, _, err = c.DoCustomRequestAndReturnRawResponseV5(ctx, "POST", "mfa/verify/totp.json", req, nil)
 			if err != nil {
 				if errors.Unwrap(err) != api.ErrAPIResponseErrorStatusCode {
-					return http.Cookie{}, fmt.Errorf("Doing MFA Challenge Response: %w", err)
+					return http.Cookie{}, fmt.Errorf("doing MFA Challenge Response: %w", err)
 				}
 				// MFA failed, so lets wait just let the loop try again
 				time.Sleep(retryDelay)
@@ -46,9 +46,9 @@ func AddMFACallbackTOTP(c *api.Client, retrys uint, retryDelay, offset time.Dura
 						return *cookie, nil
 					}
 				}
-				return http.Cookie{}, fmt.Errorf("Unable to find Passbolt MFA Cookie")
+				return http.Cookie{}, fmt.Errorf("unable to find Passbolt MFA Cookie")
 			}
 		}
-		return http.Cookie{}, fmt.Errorf("Failed MFA Challenge 3 times: %w", err)
+		return http.Cookie{}, fmt.Errorf("failed MFA Challenge 3 times: %w", err)
 	}
 }

--- a/helper/resource_create.go
+++ b/helper/resource_create.go
@@ -21,7 +21,7 @@ func CreateResource(ctx context.Context, c *api.Client, folderParentID, name, us
 
 func CreateResourceV5(ctx context.Context, c *api.Client, folderParentID, name, username, uri, password, description string) (string, error) {
 	if !c.MetadataTypeSettings().AllowCreationOfV5Resources {
-		return "", fmt.Errorf("creation of V5 Passwords is disabled on this Server")
+		return "", ErrV5CreationDisabled
 	}
 
 	types, err := c.GetResourceTypes(ctx, nil)
@@ -36,7 +36,7 @@ func CreateResourceV5(ctx context.Context, c *api.Client, folderParentID, name, 
 		}
 	}
 	if rType == nil {
-		return "", fmt.Errorf("cannot find Resource type password-and-description")
+		return "", fmt.Errorf("%w: v5-default", ErrResourceTypeSlugNotFound)
 	}
 
 	// Base Resource
@@ -115,7 +115,7 @@ func CreateResourceV5(ctx context.Context, c *api.Client, folderParentID, name, 
 
 func CreateResourceV4(ctx context.Context, c *api.Client, folderParentID, name, username, uri, password, description string) (string, error) {
 	if !c.MetadataTypeSettings().AllowCreationOfV4Resources {
-		return "", fmt.Errorf("creation of V4 Passwords is disabled on this Server")
+		return "", ErrV4CreationDisabled
 	}
 
 	types, err := c.GetResourceTypes(ctx, nil)
@@ -130,7 +130,7 @@ func CreateResourceV4(ctx context.Context, c *api.Client, folderParentID, name, 
 		}
 	}
 	if rType == nil {
-		return "", fmt.Errorf("cannot find Resource type password-and-description")
+		return "", fmt.Errorf("%w: password-and-description", ErrResourceTypeSlugNotFound)
 	}
 
 	resource := api.Resource{
@@ -177,7 +177,7 @@ func CreateResourceV4(ctx context.Context, c *api.Client, folderParentID, name, 
 // CreateResourceSimple Creates a Legacy Resource where only the Password is Encrypted and Returns the Resources ID
 func CreateResourceSimple(ctx context.Context, c *api.Client, folderParentID, name, username, uri, password, description string) (string, error) {
 	if !c.MetadataTypeSettings().AllowCreationOfV4Resources {
-		return "", fmt.Errorf("creation of V4 Passwords is disabled on this Server")
+		return "", ErrV4CreationDisabled
 	}
 
 	// TODO Create a v5-password-string if v5 is enabled

--- a/helper/resource_create.go
+++ b/helper/resource_create.go
@@ -20,13 +20,13 @@ func CreateResource(ctx context.Context, c *api.Client, folderParentID, name, us
 }
 
 func CreateResourceV5(ctx context.Context, c *api.Client, folderParentID, name, username, uri, password, description string) (string, error) {
-	if c.MetadataTypeSettings().AllowCreationOfV5Resources == false {
-		return "", fmt.Errorf("Creation of V5 Passwords is disabled on this Server")
+	if !c.MetadataTypeSettings().AllowCreationOfV5Resources {
+		return "", fmt.Errorf("creation of V5 Passwords is disabled on this Server")
 	}
 
 	types, err := c.GetResourceTypes(ctx, nil)
 	if err != nil {
-		return "", fmt.Errorf("Getting ResourceTypes: %w", err)
+		return "", fmt.Errorf("getting ResourceTypes: %w", err)
 	}
 	var rType *api.ResourceType
 	for _, tmp := range types {
@@ -36,7 +36,7 @@ func CreateResourceV5(ctx context.Context, c *api.Client, folderParentID, name, 
 		}
 	}
 	if rType == nil {
-		return "", fmt.Errorf("Cannot find Resource type password-and-description")
+		return "", fmt.Errorf("cannot find Resource type password-and-description")
 	}
 
 	// Base Resource
@@ -47,7 +47,7 @@ func CreateResourceV5(ctx context.Context, c *api.Client, folderParentID, name, 
 
 	// Resource Metadata
 	meta := api.ResourceMetadataTypeV5Default{
-		ObjectType:     api.PASSBOLT_OBJECT_TYPE_RESOURCE_METADATA,
+		ObjectType:     api.PassboltObjectTypeResourceMetadata,
 		ResourceTypeID: rType.ID,
 		Name:           name,
 		Username:       username,
@@ -56,47 +56,47 @@ func CreateResourceV5(ctx context.Context, c *api.Client, folderParentID, name, 
 
 	metaData, err := json.Marshal(&meta)
 	if err != nil {
-		return "", fmt.Errorf("Marshalling metadata: %w", err)
+		return "", fmt.Errorf("marshalling metadata: %w", err)
 	}
 
 	err = validateMetadata(rType, string(metaData))
 	if err != nil {
-		return "", fmt.Errorf("Validating metadata: %w", err)
+		return "", fmt.Errorf("validating metadata: %w", err)
 	}
 
 	metadataKeyID, metadataKeyType, publicMetadataKey, err := c.GetMetadataKey(ctx, true)
 	if err != nil {
-		return "", fmt.Errorf("Get Metadata Key: %w", err)
+		return "", fmt.Errorf("get Metadata Key: %w", err)
 	}
 	resource.MetadataKeyID = metadataKeyID
 	resource.MetadataKeyType = metadataKeyType
 
 	encMetadata, err := c.EncryptMessageWithKey(publicMetadataKey, string(metaData))
 	if err != nil {
-		return "", fmt.Errorf("Encrypt Metadata: %w", err)
+		return "", fmt.Errorf("encrypt Metadata: %w", err)
 	}
 	resource.Metadata = encMetadata
 
 	// Resource Secret
 	secret := api.SecretDataTypeV5Default{
-		ObjectType:  api.PASSBOLT_OBJECT_TYPE_SECRET_DATA,
+		ObjectType:  api.PassboltObjectTypeSecretData,
 		Password:    password,
 		Description: description,
 	}
 
 	secretData, err := json.Marshal(&secret)
 	if err != nil {
-		return "", fmt.Errorf("Marshalling Secret Data: %w", err)
+		return "", fmt.Errorf("marshalling Secret Data: %w", err)
 	}
 
 	err = validateSecretData(rType, string(secretData))
 	if err != nil {
-		return "", fmt.Errorf("Validating Secret Data: %w", err)
+		return "", fmt.Errorf("validating Secret Data: %w", err)
 	}
 
 	encSecretData, err := c.EncryptMessage(string(secretData))
 	if err != nil {
-		return "", fmt.Errorf("Encrypting Secret Data for User me: %w", err)
+		return "", fmt.Errorf("encrypting Secret Data for User me: %w", err)
 	}
 	resource.Secrets = []api.Secret{{Data: encSecretData}}
 
@@ -108,19 +108,19 @@ func CreateResourceV5(ctx context.Context, c *api.Client, folderParentID, name, 
 
 	newresource, err := c.CreateResource(ctx, resource)
 	if err != nil {
-		return "", fmt.Errorf("Creating Resource: %w", err)
+		return "", fmt.Errorf("creating Resource: %w", err)
 	}
 	return newresource.ID, nil
 }
 
 func CreateResourceV4(ctx context.Context, c *api.Client, folderParentID, name, username, uri, password, description string) (string, error) {
-	if c.MetadataTypeSettings().AllowCreationOfV4Resources == false {
-		return "", fmt.Errorf("Creation of V4 Passwords is disabled on this Server")
+	if !c.MetadataTypeSettings().AllowCreationOfV4Resources {
+		return "", fmt.Errorf("creation of V4 Passwords is disabled on this Server")
 	}
 
 	types, err := c.GetResourceTypes(ctx, nil)
 	if err != nil {
-		return "", fmt.Errorf("Getting ResourceTypes: %w", err)
+		return "", fmt.Errorf("getting ResourceTypes: %w", err)
 	}
 	var rType *api.ResourceType
 	for _, tmp := range types {
@@ -130,7 +130,7 @@ func CreateResourceV4(ctx context.Context, c *api.Client, folderParentID, name, 
 		}
 	}
 	if rType == nil {
-		return "", fmt.Errorf("Cannot find Resource type password-and-description")
+		return "", fmt.Errorf("cannot find Resource type password-and-description")
 	}
 
 	resource := api.Resource{
@@ -147,17 +147,17 @@ func CreateResourceV4(ctx context.Context, c *api.Client, folderParentID, name, 
 	}
 	secretData, err := json.Marshal(&tmp)
 	if err != nil {
-		return "", fmt.Errorf("Marshalling Secret Data: %w", err)
+		return "", fmt.Errorf("marshalling Secret Data: %w", err)
 	}
 
 	err = validateSecretData(rType, string(secretData))
 	if err != nil {
-		return "", fmt.Errorf("Validating Secret Data: %w", err)
+		return "", fmt.Errorf("validating Secret Data: %w", err)
 	}
 
 	encSecretData, err := c.EncryptMessage(string(secretData))
 	if err != nil {
-		return "", fmt.Errorf("Encrypting Secret Data for User me: %w", err)
+		return "", fmt.Errorf("encrypting Secret Data for User me: %w", err)
 	}
 	resource.Secrets = []api.Secret{{Data: encSecretData}}
 
@@ -169,22 +169,22 @@ func CreateResourceV4(ctx context.Context, c *api.Client, folderParentID, name, 
 
 	newresource, err := c.CreateResource(ctx, resource)
 	if err != nil {
-		return "", fmt.Errorf("Creating Resource: %w", err)
+		return "", fmt.Errorf("creating Resource: %w", err)
 	}
 	return newresource.ID, nil
 }
 
 // CreateResourceSimple Creates a Legacy Resource where only the Password is Encrypted and Returns the Resources ID
 func CreateResourceSimple(ctx context.Context, c *api.Client, folderParentID, name, username, uri, password, description string) (string, error) {
-	if c.MetadataTypeSettings().AllowCreationOfV4Resources == false {
-		return "", fmt.Errorf("Creation of V4 Passwords is disabled on this Server")
+	if !c.MetadataTypeSettings().AllowCreationOfV4Resources {
+		return "", fmt.Errorf("creation of V4 Passwords is disabled on this Server")
 	}
 
 	// TODO Create a v5-password-string if v5 is enabled
 
 	enc, err := c.EncryptMessage(password)
 	if err != nil {
-		return "", fmt.Errorf("Encrypting Password: %w", err)
+		return "", fmt.Errorf("encrypting Password: %w", err)
 	}
 
 	res := api.Resource{
@@ -200,7 +200,7 @@ func CreateResourceSimple(ctx context.Context, c *api.Client, folderParentID, na
 
 	resource, err := c.CreateResource(ctx, res)
 	if err != nil {
-		return "", fmt.Errorf("Creating Resource: %w", err)
+		return "", fmt.Errorf("creating Resource: %w", err)
 	}
 	return resource.ID, nil
 }

--- a/helper/resource_get.go
+++ b/helper/resource_get.go
@@ -12,16 +12,16 @@ import (
 func GetResource(ctx context.Context, c *api.Client, resourceID string) (folderParentID, name, username, uri, password, description string, err error) {
 	resource, err := c.GetResource(ctx, resourceID)
 	if err != nil {
-		return "", "", "", "", "", "", fmt.Errorf("Getting Resource: %w", err)
+		return "", "", "", "", "", "", fmt.Errorf("getting Resource: %w", err)
 	}
 
 	rType, err := c.GetResourceType(ctx, resource.ResourceTypeID)
 	if err != nil {
-		return "", "", "", "", "", "", fmt.Errorf("Getting ResourceType: %w", err)
+		return "", "", "", "", "", "", fmt.Errorf("getting ResourceType: %w", err)
 	}
 	secret, err := c.GetSecret(ctx, resource.ID)
 	if err != nil {
-		return "", "", "", "", "", "", fmt.Errorf("Getting Resource Secret: %w", err)
+		return "", "", "", "", "", "", fmt.Errorf("getting Resource Secret: %w", err)
 	}
 	return GetResourceFromData(c, *resource, *secret, *rType)
 }
@@ -53,12 +53,12 @@ func GetResourceFromDataWithOptions(c *api.Client, resource api.Resource, secret
 	if decryptSecret && secret.Data != "" {
 		rawSecretData, err = c.DecryptSecretWithResourceID(resource.ID, secret.Data)
 		if err != nil {
-			return "", "", "", "", "", "", fmt.Errorf("Decrypting Secret Data: %w", err)
+			return "", "", "", "", "", "", fmt.Errorf("decrypting Secret Data: %w", err)
 		}
 
 		err = validateSecretData(&rType, rawSecretData)
 		if err != nil {
-			return "", "", "", "", "", "", fmt.Errorf("Validate Secret Data: %w", err)
+			return "", "", "", "", "", "", fmt.Errorf("validate Secret Data: %w", err)
 		}
 	}
 
@@ -78,7 +78,7 @@ func GetResourceFromDataWithOptions(c *api.Client, resource api.Resource, secret
 			var secretData api.SecretDataTypePasswordAndDescription
 			err = json.Unmarshal([]byte(rawSecretData), &secretData)
 			if err != nil {
-				return "", "", "", "", "", "", fmt.Errorf("Parsing Decrypted Secret Data: %w", err)
+				return "", "", "", "", "", "", fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 			}
 			pw = secretData.Password
 			desc = secretData.Description
@@ -92,7 +92,7 @@ func GetResourceFromDataWithOptions(c *api.Client, resource api.Resource, secret
 			var secretData api.SecretDataTypePasswordDescriptionTOTP
 			err = json.Unmarshal([]byte(rawSecretData), &secretData)
 			if err != nil {
-				return "", "", "", "", "", "", fmt.Errorf("Parsing Decrypted Secret Data: %w", err)
+				return "", "", "", "", "", "", fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 			}
 			pw = secretData.Password
 			desc = secretData.Description
@@ -105,13 +105,13 @@ func GetResourceFromDataWithOptions(c *api.Client, resource api.Resource, secret
 	case "v5-default":
 		rawMetadata, err := GetResourceMetadata(ctx, c, &resource, &rType)
 		if err != nil {
-			return "", "", "", "", "", "", fmt.Errorf("Getting Metadata: %w", err)
+			return "", "", "", "", "", "", fmt.Errorf("getting Metadata: %w", err)
 		}
 
 		var metadata api.ResourceMetadataTypeV5Default
 		err = json.Unmarshal([]byte(rawMetadata), &metadata)
 		if err != nil {
-			return "", "", "", "", "", "", fmt.Errorf("Parsing Decrypted Metadata: %w", err)
+			return "", "", "", "", "", "", fmt.Errorf("parsing Decrypted Metadata: %w", err)
 		}
 
 		name = metadata.Name
@@ -125,7 +125,7 @@ func GetResourceFromDataWithOptions(c *api.Client, resource api.Resource, secret
 			var secretData api.SecretDataTypeV5Default
 			err = json.Unmarshal([]byte(rawSecretData), &secretData)
 			if err != nil {
-				return "", "", "", "", "", "", fmt.Errorf("Parsing Decrypted Secret Data: %w", err)
+				return "", "", "", "", "", "", fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 			}
 			pw = secretData.Password
 			desc = secretData.Description
@@ -133,13 +133,13 @@ func GetResourceFromDataWithOptions(c *api.Client, resource api.Resource, secret
 	case "v5-default-with-totp":
 		rawMetadata, err := GetResourceMetadata(ctx, c, &resource, &rType)
 		if err != nil {
-			return "", "", "", "", "", "", fmt.Errorf("Getting Metadata: %w", err)
+			return "", "", "", "", "", "", fmt.Errorf("getting Metadata: %w", err)
 		}
 
 		var metadata api.ResourceMetadataTypeV5DefaultWithTOTP
 		err = json.Unmarshal([]byte(rawMetadata), &metadata)
 		if err != nil {
-			return "", "", "", "", "", "", fmt.Errorf("Parsing Decrypted Metadata: %w", err)
+			return "", "", "", "", "", "", fmt.Errorf("parsing Decrypted Metadata: %w", err)
 		}
 
 		name = metadata.Name
@@ -153,7 +153,7 @@ func GetResourceFromDataWithOptions(c *api.Client, resource api.Resource, secret
 			var secretData api.SecretDataTypeV5DefaultWithTOTP
 			err = json.Unmarshal([]byte(rawSecretData), &secretData)
 			if err != nil {
-				return "", "", "", "", "", "", fmt.Errorf("Parsing Decrypted Secret Data: %w", err)
+				return "", "", "", "", "", "", fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 			}
 			pw = secretData.Password
 			desc = secretData.Description
@@ -161,13 +161,13 @@ func GetResourceFromDataWithOptions(c *api.Client, resource api.Resource, secret
 	case "v5-password-string":
 		rawMetadata, err := GetResourceMetadata(ctx, c, &resource, &rType)
 		if err != nil {
-			return "", "", "", "", "", "", fmt.Errorf("Getting Metadata: %w", err)
+			return "", "", "", "", "", "", fmt.Errorf("getting Metadata: %w", err)
 		}
 
 		var metadata api.ResourceMetadataTypeV5PasswordString
 		err = json.Unmarshal([]byte(rawMetadata), &metadata)
 		if err != nil {
-			return "", "", "", "", "", "", fmt.Errorf("Parsing Decrypted Metadata: %w", err)
+			return "", "", "", "", "", "", fmt.Errorf("parsing Decrypted Metadata: %w", err)
 		}
 
 		name = metadata.Name
@@ -183,13 +183,13 @@ func GetResourceFromDataWithOptions(c *api.Client, resource api.Resource, secret
 	case "v5-totp-standalone":
 		rawMetadata, err := GetResourceMetadata(ctx, c, &resource, &rType)
 		if err != nil {
-			return "", "", "", "", "", "", fmt.Errorf("Getting Metadata: %w", err)
+			return "", "", "", "", "", "", fmt.Errorf("getting Metadata: %w", err)
 		}
 
 		var metadata api.ResourceMetadataTypeV5TOTPStandalone
 		err = json.Unmarshal([]byte(rawMetadata), &metadata)
 		if err != nil {
-			return "", "", "", "", "", "", fmt.Errorf("Parsing Decrypted Metadata: %w", err)
+			return "", "", "", "", "", "", fmt.Errorf("parsing Decrypted Metadata: %w", err)
 		}
 
 		name = metadata.Name

--- a/helper/resource_update.go
+++ b/helper/resource_update.go
@@ -15,12 +15,12 @@ import (
 func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, username, uri, password, description string) error {
 	resource, err := c.GetResource(ctx, resourceID)
 	if err != nil {
-		return fmt.Errorf("Getting Resource: %w", err)
+		return fmt.Errorf("getting Resource: %w", err)
 	}
 
 	rType, err := c.GetResourceType(ctx, resource.ResourceTypeID)
 	if err != nil {
-		return fmt.Errorf("Getting ResourceType: %w", err)
+		return fmt.Errorf("getting ResourceType: %w", err)
 	}
 
 	opts := &api.GetUsersOptions{
@@ -28,7 +28,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 	}
 	users, err := c.GetUsers(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Getting Users: %w", err)
+		return fmt.Errorf("getting Users: %w", err)
 	}
 
 	newResource := api.Resource{
@@ -43,13 +43,13 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 		// Get Metadata
 		orgMetadata, err := GetResourceMetadata(ctx, c, resource, rType)
 		if err != nil {
-			return fmt.Errorf("Get Resource metadata: %w", err)
+			return fmt.Errorf("get Resource metadata: %w", err)
 		}
 
 		var metadataMap map[string]any
 		err = json.Unmarshal([]byte(orgMetadata), &metadataMap)
 		if err != nil {
-			return fmt.Errorf("Marshalling metadata: %w", err)
+			return fmt.Errorf("marshalling metadata: %w", err)
 		}
 
 		var newMetadata []byte
@@ -104,13 +104,13 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 		newMetadata, err = json.Marshal(&metadataMap)
 		if err != nil {
-			return fmt.Errorf("Marshalling metadata: %w", err)
+			return fmt.Errorf("marshalling metadata: %w", err)
 		}
 
 		// Validate Metadata
 		err = validateMetadata(rType, string(newMetadata))
 		if err != nil {
-			return fmt.Errorf("Validating metadata: %w", err)
+			return fmt.Errorf("validating metadata: %w", err)
 		}
 
 		personal := true
@@ -120,14 +120,14 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 		metadataKeyID, metadataKeyType, publicMetadataKey, err := c.GetMetadataKey(ctx, personal)
 		if err != nil {
-			return fmt.Errorf("Get Metadata Key: %w", err)
+			return fmt.Errorf("get Metadata Key: %w", err)
 		}
 		newResource.MetadataKeyID = metadataKeyID
 		newResource.MetadataKeyType = metadataKeyType
 
 		encMetadata, err := c.EncryptMessageWithKey(publicMetadataKey, string(newMetadata))
 		if err != nil {
-			return fmt.Errorf("Encrypt Metadata: %w", err)
+			return fmt.Errorf("encrypt Metadata: %w", err)
 		}
 		newResource.Metadata = encMetadata
 
@@ -137,23 +137,23 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 			// Always fetch existing secret to preserve password/description for metadata-only updates
 			secret, err := c.GetSecret(ctx, resourceID)
 			if err != nil {
-				return fmt.Errorf("Getting Secret: %w", err)
+				return fmt.Errorf("getting Secret: %w", err)
 			}
 			oldSecretData, err := c.DecryptMessage(secret.Data)
 			if err != nil {
-				return fmt.Errorf("Decrypting Secret: %w", err)
+				return fmt.Errorf("decrypting Secret: %w", err)
 			}
 			var oldSecret api.SecretDataTypeV5Default
 			err = json.Unmarshal([]byte(oldSecretData), &oldSecret)
 			if err != nil {
-				return fmt.Errorf("Parsing Decrypted Secret Data: %w", err)
+				return fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 			}
 
 			tmp := api.SecretDataTypeV5Default{
 				Password:    oldSecret.Password,
 				Description: oldSecret.Description,
 			}
-			tmp.ObjectType = api.PASSBOLT_OBJECT_TYPE_SECRET_DATA
+			tmp.ObjectType = api.PassboltObjectTypeSecretData
 			tmp.ResourceTypeID = rType.ID
 
 			// Override with new values if provided
@@ -165,7 +165,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 			}
 			res, err := json.Marshal(&tmp)
 			if err != nil {
-				return fmt.Errorf("Marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshalling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		case "v5-password-string":
@@ -174,26 +174,26 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 			} else {
 				secret, err := c.GetSecret(ctx, resourceID)
 				if err != nil {
-					return fmt.Errorf("Getting Secret: %w", err)
+					return fmt.Errorf("getting Secret: %w", err)
 				}
 				secretData, err = c.DecryptMessage(secret.Data)
 				if err != nil {
-					return fmt.Errorf("Decrypting Secret: %w", err)
+					return fmt.Errorf("decrypting Secret: %w", err)
 				}
 			}
 		case "v5-default-with-totp":
 			secret, err := c.GetSecret(ctx, resourceID)
 			if err != nil {
-				return fmt.Errorf("Getting Secret: %w", err)
+				return fmt.Errorf("getting Secret: %w", err)
 			}
 			oldSecretData, err := c.DecryptMessage(secret.Data)
 			if err != nil {
-				return fmt.Errorf("Decrypting Secret: %w", err)
+				return fmt.Errorf("decrypting Secret: %w", err)
 			}
 			var oldSecret api.SecretDataTypeV5DefaultWithTOTP
 			err = json.Unmarshal([]byte(oldSecretData), &secretData)
 			if err != nil {
-				return fmt.Errorf("Parsing Decrypted Secret Data: %w", err)
+				return fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 			}
 			if password != "" {
 				oldSecret.Password = password
@@ -204,28 +204,28 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 			res, err := json.Marshal(&oldSecret)
 			if err != nil {
-				return fmt.Errorf("Marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshalling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		case "v5-totp-standalone":
 			secret, err := c.GetSecret(ctx, resourceID)
 			if err != nil {
-				return fmt.Errorf("Getting Secret: %w", err)
+				return fmt.Errorf("getting Secret: %w", err)
 			}
 			oldSecretData, err := c.DecryptMessage(secret.Data)
 			if err != nil {
-				return fmt.Errorf("Decrypting Secret: %w", err)
+				return fmt.Errorf("decrypting Secret: %w", err)
 			}
 			var oldSecret api.SecretDataTypeTOTP
 			err = json.Unmarshal([]byte(oldSecretData), &secretData)
 			if err != nil {
-				return fmt.Errorf("Parsing Decrypted Secret Data: %w", err)
+				return fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 			}
 			// since we don't have totp parameters we don't do anything
 
 			res, err := json.Marshal(&oldSecret)
 			if err != nil {
-				return fmt.Errorf("Marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshalling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		default:
@@ -259,11 +259,11 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 			} else {
 				secret, err := c.GetSecret(ctx, resourceID)
 				if err != nil {
-					return fmt.Errorf("Getting Secret: %w", err)
+					return fmt.Errorf("getting Secret: %w", err)
 				}
 				secretData, err = c.DecryptMessage(secret.Data)
 				if err != nil {
-					return fmt.Errorf("Decrypting Secret: %w", err)
+					return fmt.Errorf("decrypting Secret: %w", err)
 				}
 			}
 		case "password-and-description":
@@ -274,16 +274,16 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 			if password != "" || description != "" {
 				secret, err := c.GetSecret(ctx, resourceID)
 				if err != nil {
-					return fmt.Errorf("Getting Secret: %w", err)
+					return fmt.Errorf("getting Secret: %w", err)
 				}
 				oldSecretData, err := c.DecryptMessage(secret.Data)
 				if err != nil {
-					return fmt.Errorf("Decrypting Secret: %w", err)
+					return fmt.Errorf("decrypting Secret: %w", err)
 				}
 				var oldSecret api.SecretDataTypePasswordAndDescription
 				err = json.Unmarshal([]byte(oldSecretData), &oldSecret)
 				if err != nil {
-					return fmt.Errorf("Parsing Decrypted Secret Data: %w", err)
+					return fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 				}
 				if password == "" {
 					tmp.Password = oldSecret.Password
@@ -294,22 +294,22 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 			}
 			res, err := json.Marshal(&tmp)
 			if err != nil {
-				return fmt.Errorf("Marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshalling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		case "password-description-totp":
 			secret, err := c.GetSecret(ctx, resourceID)
 			if err != nil {
-				return fmt.Errorf("Getting Secret: %w", err)
+				return fmt.Errorf("getting Secret: %w", err)
 			}
 			oldSecretData, err := c.DecryptMessage(secret.Data)
 			if err != nil {
-				return fmt.Errorf("Decrypting Secret: %w", err)
+				return fmt.Errorf("decrypting Secret: %w", err)
 			}
 			var oldSecret api.SecretDataTypePasswordDescriptionTOTP
 			err = json.Unmarshal([]byte(oldSecretData), &secretData)
 			if err != nil {
-				return fmt.Errorf("Parsing Decrypted Secret Data: %w", err)
+				return fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 			}
 			if password != "" {
 				oldSecret.Password = password
@@ -320,28 +320,28 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 			res, err := json.Marshal(&oldSecret)
 			if err != nil {
-				return fmt.Errorf("Marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshalling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		case "totp":
 			secret, err := c.GetSecret(ctx, resourceID)
 			if err != nil {
-				return fmt.Errorf("Getting Secret: %w", err)
+				return fmt.Errorf("getting Secret: %w", err)
 			}
 			oldSecretData, err := c.DecryptMessage(secret.Data)
 			if err != nil {
-				return fmt.Errorf("Decrypting Secret: %w", err)
+				return fmt.Errorf("decrypting Secret: %w", err)
 			}
 			var oldSecret api.SecretDataTypeTOTP
 			err = json.Unmarshal([]byte(oldSecretData), &secretData)
 			if err != nil {
-				return fmt.Errorf("Parsing Decrypted Secret Data: %w", err)
+				return fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 			}
 			// since we don't have totp parameters we don't do anything
 
 			res, err := json.Marshal(&oldSecret)
 			if err != nil {
-				return fmt.Errorf("Marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshalling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		default:
@@ -351,7 +351,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 	err = validateSecretData(rType, secretData)
 	if err != nil {
-		return fmt.Errorf("Validating Secret Data: %w", err)
+		return fmt.Errorf("validating Secret Data: %w", err)
 	}
 
 	newResource.Secrets = []api.Secret{}
@@ -361,17 +361,17 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 		if user.ID == c.GetUserID() {
 			encSecretData, err = c.EncryptMessage(secretData)
 			if err != nil {
-				return fmt.Errorf("Encrypting Secret Data for User me: %w", err)
+				return fmt.Errorf("encrypting Secret Data for User me: %w", err)
 			}
 		} else {
 			publicKey, err := crypto.NewKeyFromArmored(user.GPGKey.ArmoredKey)
 			if err != nil {
-				return fmt.Errorf("Get Public Key: %w", err)
+				return fmt.Errorf("get Public Key: %w", err)
 			}
 
 			encSecretData, err = c.EncryptMessageWithKey(publicKey, secretData)
 			if err != nil {
-				return fmt.Errorf("Encrypting Secret Data for User %v: %w", user.ID, err)
+				return fmt.Errorf("encrypting Secret Data for User %v: %w", user.ID, err)
 			}
 		}
 		newResource.Secrets = append(newResource.Secrets, api.Secret{
@@ -388,7 +388,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 	_, err = c.UpdateResource(ctx, resourceID, newResource)
 	if err != nil {
-		return fmt.Errorf("Updating Resource: %w", err)
+		return fmt.Errorf("updating Resource: %w", err)
 	}
 	return nil
 }

--- a/helper/resources.go
+++ b/helper/resources.go
@@ -11,7 +11,7 @@ import (
 func DeleteResource(ctx context.Context, c *api.Client, resourceID string) error {
 	err := c.DeleteResource(ctx, resourceID)
 	if err != nil {
-		return fmt.Errorf("Deleting Resource: %w", err)
+		return fmt.Errorf("deleting Resource: %w", err)
 	}
 	return nil
 }
@@ -20,7 +20,7 @@ func DeleteResource(ctx context.Context, c *api.Client, resourceID string) error
 func MoveResource(ctx context.Context, c *api.Client, resourceID, folderParentID string) error {
 	err := c.MoveResource(ctx, resourceID, folderParentID)
 	if err != nil {
-		return fmt.Errorf("Moveing Resource: %w", err)
+		return fmt.Errorf("moving Resource: %w", err)
 	}
 	return err
 }

--- a/helper/secret.go
+++ b/helper/secret.go
@@ -37,16 +37,16 @@ func validateSecretData(rType *api.ResourceType, secretData string) error {
 			var tmp string
 			err = json.Unmarshal([]byte(definition), &tmp)
 			if err != nil {
-				return fmt.Errorf("Workaround Unmarshal Json Schema String: %w", err)
+				return fmt.Errorf("workaround Unmarshal Json Schema String: %w", err)
 			}
 
 			err = json.Unmarshal([]byte(tmp), &schemaDefinition)
 			if err != nil {
-				return fmt.Errorf("Workaround Unmarshal Json Schema: %w", err)
+				return fmt.Errorf("workaround Unmarshal Json Schema: %w", err)
 			}
 
 		} else {
-			return fmt.Errorf("Unmarshal Json Schema: %w", err)
+			return fmt.Errorf("unmarshal Json Schema: %w", err)
 		}
 	}
 
@@ -54,23 +54,23 @@ func validateSecretData(rType *api.ResourceType, secretData string) error {
 
 	err = comp.AddResource("secret.json", schemaDefinition.Secret)
 	if err != nil {
-		return fmt.Errorf("Adding Json Schema: %w", err)
+		return fmt.Errorf("adding Json Schema: %w", err)
 	}
 
 	schema, err := comp.Compile("secret.json")
 	if err != nil {
-		return fmt.Errorf("Compiling Json Schema: %w", err)
+		return fmt.Errorf("compiling Json Schema: %w", err)
 	}
 
 	var parsedSecretData map[string]any
 	err = json.Unmarshal([]byte(secretData), &parsedSecretData)
 	if err != nil {
-		return fmt.Errorf("Unmarshal Secret: %w", err)
+		return fmt.Errorf("unmarshal Secret: %w", err)
 	}
 
 	err = schema.Validate(parsedSecretData)
 	if err != nil {
-		return fmt.Errorf("Validating Secret Data with Schema: %w", err)
+		return fmt.Errorf("validating Secret Data with Schema: %w", err)
 	}
 	return nil
 }

--- a/helper/secret.go
+++ b/helper/secret.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/passbolt/go-passbolt/api"
@@ -13,7 +14,7 @@ func validateSecretData(rType *api.ResourceType, secretData string) error {
 	// with the Resource Type password-string the Secret is not json and can't be properly validated, so skip the check here
 	if rType.Slug == "password-string" || rType.Slug == "v5-password-string" {
 		if len(secretData) > 4096 {
-			return fmt.Errorf("password is longer than 4096")
+			return ErrPasswordTooLong
 		}
 		return nil
 	}
@@ -32,8 +33,9 @@ func validateSecretData(rType *api.ResourceType, secretData string) error {
 
 	err := json.Unmarshal([]byte(definition), &schemaDefinition)
 	if err != nil {
-		// Workaround for inconsistant API Responses where sometime the Schema is embedded directly and sometimes it's escaped as a string
-		if err.Error() == "json: cannot unmarshal string into Go value of type api.ResourceTypeSchema" {
+		// Workaround for inconsistent API Responses where sometimes the Schema is embedded directly and sometimes it's escaped as a string
+		var unmarshalErr *json.UnmarshalTypeError
+		if errors.As(err, &unmarshalErr) {
 			var tmp string
 			err = json.Unmarshal([]byte(definition), &tmp)
 			if err != nil {
@@ -44,7 +46,6 @@ func validateSecretData(rType *api.ResourceType, secretData string) error {
 			if err != nil {
 				return fmt.Errorf("workaround Unmarshal Json Schema: %w", err)
 			}
-
 		} else {
 			return fmt.Errorf("unmarshal Json Schema: %w", err)
 		}

--- a/helper/setup.go
+++ b/helper/setup.go
@@ -17,7 +17,6 @@ func ParseInviteURL(url string) (string, string, error) {
 	return split[len(split)-2], strings.TrimSuffix(split[len(split)-1], ".json"), nil
 }
 
-
 // SetupAccount Setup a Account for a Invited User.
 // (Use ParseInviteURL to get the userid and token from a Invite URL)
 func SetupAccount(ctx context.Context, c *api.Client, userID, token, password string) (string, error) {

--- a/helper/setup.go
+++ b/helper/setup.go
@@ -8,22 +8,23 @@ import (
 	"github.com/passbolt/go-passbolt/api"
 )
 
-// ParseInviteUrl Parses a Passbolt Invite URL into a user id and token
-func ParseInviteUrl(url string) (string, string, error) {
+// ParseInviteURL parses a Passbolt Invite URL into a user id and token.
+func ParseInviteURL(url string) (string, string, error) {
 	split := strings.Split(url, "/")
 	if len(split) < 4 {
-		return "", "", fmt.Errorf("Invite URL does not have enough slashes")
+		return "", "", fmt.Errorf("invite URL does not have enough slashes")
 	}
 	return split[len(split)-2], strings.TrimSuffix(split[len(split)-1], ".json"), nil
 }
 
+
 // SetupAccount Setup a Account for a Invited User.
-// (Use ParseInviteUrl to get the userid and token from a Invite URL)
+// (Use ParseInviteURL to get the userid and token from a Invite URL)
 func SetupAccount(ctx context.Context, c *api.Client, userID, token, password string) (string, error) {
 
 	install, err := c.SetupInstall(ctx, userID, token)
 	if err != nil {
-		return "", fmt.Errorf("Get Setup Install Data: %w", err)
+		return "", fmt.Errorf("get Setup Install Data: %w", err)
 	}
 
 	keyName := install.Profile.FirstName + " " + install.Profile.LastName + " " + install.Username
@@ -34,26 +35,26 @@ func SetupAccount(ctx context.Context, c *api.Client, userID, token, password st
 
 	key, err := keyHandler.GenerateKey()
 	if err != nil {
-		return "", fmt.Errorf("Generating Private Key: %w", err)
+		return "", fmt.Errorf("generating Private Key: %w", err)
 	}
 
 	defer key.ClearPrivateParams()
 
 	publicKey, err := key.GetArmoredPublicKey()
 	if err != nil {
-		return "", fmt.Errorf("Get Public Key: %w", err)
+		return "", fmt.Errorf("get Public Key: %w", err)
 	}
 
 	lockedKey, err := pgp.LockKey(key, []byte(password))
 	if err != nil {
-		return "", fmt.Errorf("Locking Private Key: %w", err)
+		return "", fmt.Errorf("locking Private Key: %w", err)
 	}
 
 	defer lockedKey.ClearPrivateParams()
 
 	privateKey, err := lockedKey.Armor()
 	if err != nil {
-		return "", fmt.Errorf("Get Private Key: %w", err)
+		return "", fmt.Errorf("get Private Key: %w", err)
 	}
 
 	request := api.SetupCompleteRequest{
@@ -70,7 +71,7 @@ func SetupAccount(ctx context.Context, c *api.Client, userID, token, password st
 
 	err = c.SetupComplete(ctx, userID, request)
 	if err != nil {
-		return "", fmt.Errorf("Setup Completion Failed: %w", err)
+		return "", fmt.Errorf("setup Completion Failed: %w", err)
 	}
 	return privateKey, nil
 }

--- a/helper/setup_test.go
+++ b/helper/setup_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 	}
 
 	fmt.Printf("Registering with url: %v\n", url)
-	userID, token, err := ParseInviteUrl(url)
+	userID, token, err := ParseInviteURL(url)
 	if err != nil {
 		panic(fmt.Errorf("Unable to Parse Invite URL: %w", err))
 	}
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 	// Debug Output
 	c.Debug = true
 
-	c.Login(ctx)
+	err = c.Login(ctx)
 	if err != nil {
 		panic(fmt.Errorf("Login Client: %w", err))
 	}

--- a/helper/share.go
+++ b/helper/share.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ProtonMail/gopenpgp/v3/crypto"
 	"github.com/passbolt/go-passbolt/api"
 )
 
@@ -43,40 +44,40 @@ func ShareResourceWithUsersAndGroups(ctx context.Context, c *api.Client, resourc
 func ShareResource(ctx context.Context, c *api.Client, resourceID string, changes []ShareOperation) error {
 	oldPermissions, err := c.GetResourcePermissions(ctx, resourceID)
 	if err != nil {
-		return fmt.Errorf("Getting Resource Permissions: %w", err)
+		return fmt.Errorf("getting Resource Permissions: %w", err)
 	}
 
 	permissionChanges, err := GeneratePermissionChanges(oldPermissions, changes)
 	if err != nil {
-		return fmt.Errorf("Generating Resource Permission Changes: %w", err)
+		return fmt.Errorf("generating Resource Permission Changes: %w", err)
 	}
 
 	shareRequest := api.ResourceShareRequest{Permissions: permissionChanges}
 
 	secret, err := c.GetSecret(ctx, resourceID)
 	if err != nil {
-		return fmt.Errorf("Get Resource: %w", err)
+		return fmt.Errorf("get Resource: %w", err)
 	}
 
 	secretData, err := c.DecryptMessage(secret.Data)
 	if err != nil {
-		return fmt.Errorf("Decrypting Resource Secret: %w", err)
+		return fmt.Errorf("decrypting Resource Secret: %w", err)
 	}
 
 	// Secret Validation
 	resource, err := c.GetResource(ctx, resourceID)
 	if err != nil {
-		return fmt.Errorf("Getting Resource: %w", err)
+		return fmt.Errorf("getting Resource: %w", err)
 	}
 
 	rType, err := c.GetResourceType(ctx, resource.ResourceTypeID)
 	if err != nil {
-		return fmt.Errorf("Getting ResourceType: %w", err)
+		return fmt.Errorf("getting ResourceType: %w", err)
 	}
 
 	err = validateSecretData(rType, secretData)
 	if err != nil {
-		return fmt.Errorf("Validating Secret Data: %w", err)
+		return fmt.Errorf("validating Secret Data: %w", err)
 	}
 
 	// if Metadata has not been shared yet then we need to do that
@@ -85,31 +86,31 @@ func ShareResource(ctx context.Context, c *api.Client, resourceID string, change
 	if resource.MetadataKeyType == api.MetadataKeyTypeUserKey {
 		metadata, err := GetResourceMetadata(ctx, c, resource, rType)
 		if err != nil {
-			return fmt.Errorf("Get Metadata: %w", err)
+			return fmt.Errorf("get Metadata: %w", err)
 		}
 
 		metadataKeyID, metadataKeyType, publicMetadataKey, err := c.GetMetadataKey(ctx, false)
 		if err != nil {
-			return fmt.Errorf("Get Metadata Key: %w", err)
+			return fmt.Errorf("get Metadata Key: %w", err)
 		}
 		resource.MetadataKeyID = metadataKeyID
 		resource.MetadataKeyType = metadataKeyType
 
 		encMetadata, err := c.EncryptMessageWithKey(publicMetadataKey, string(metadata))
 		if err != nil {
-			return fmt.Errorf("Encrypt Metadata: %w", err)
+			return fmt.Errorf("encrypt Metadata: %w", err)
 		}
 		resource.Metadata = encMetadata
 
-		resource, err = c.UpdateResource(ctx, resource.ID, *resource)
+		_, err = c.UpdateResource(ctx, resource.ID, *resource)
 		if err != nil {
-			return fmt.Errorf("Update Resource Metadata to Shared key: %w", err)
+			return fmt.Errorf("update Resource Metadata to Shared key: %w", err)
 		}
 	}
 
 	simulationResult, err := c.SimulateShareResource(ctx, resourceID, shareRequest)
 	if err != nil {
-		return fmt.Errorf("Simulate Share Resource: %w", err)
+		return fmt.Errorf("simulate Share Resource: %w", err)
 	}
 
 	// if no users where added then we can skip this
@@ -117,7 +118,7 @@ func ShareResource(ctx context.Context, c *api.Client, resourceID string, change
 	if len(simulationResult.Changes.Added) != 0 {
 		users, err = c.GetUsers(ctx, nil)
 		if err != nil {
-			return fmt.Errorf("Get Users: %w", err)
+			return fmt.Errorf("get Users: %w", err)
 		}
 	}
 
@@ -125,12 +126,17 @@ func ShareResource(ctx context.Context, c *api.Client, resourceID string, change
 	for _, user := range simulationResult.Changes.Added {
 		pubkey, err := getPublicKeyByUserID(user.User.ID, users)
 		if err != nil {
-			return fmt.Errorf("Getting Public Key for User %v: %w", user.User.ID, err)
+			return fmt.Errorf("getting Public Key for User %v: %w", user.User.ID, err)
 		}
 
-		encSecretData, err := c.EncryptMessageWithPublicKey(pubkey, secretData)
+		publicKey, err := crypto.NewKeyFromArmored(pubkey)
 		if err != nil {
-			return fmt.Errorf("Encrypting Secret for User %v: %w", user.User.ID, err)
+			return fmt.Errorf("parsing public key for user %v: %w", user.User.ID, err)
+		}
+
+		encSecretData, err := c.EncryptMessageWithKey(publicKey, secretData)
+		if err != nil {
+			return fmt.Errorf("encrypting Secret for User %v: %w", user.User.ID, err)
 		}
 		shareRequest.Secrets = append(shareRequest.Secrets, api.Secret{
 			UserID: user.User.ID,
@@ -140,7 +146,7 @@ func ShareResource(ctx context.Context, c *api.Client, resourceID string, change
 
 	err = c.ShareResource(ctx, resourceID, shareRequest)
 	if err != nil {
-		return fmt.Errorf("Sharing Resource: %w", err)
+		return fmt.Errorf("sharing Resource: %w", err)
 	}
 	return nil
 }
@@ -174,17 +180,17 @@ func ShareFolder(ctx context.Context, c *api.Client, folderID string, changes []
 		ContainPermissions: true,
 	})
 	if err != nil {
-		return fmt.Errorf("Getting Folder Permissions: %w", err)
+		return fmt.Errorf("getting Folder Permissions: %w", err)
 	}
 
 	permissionChanges, err := GeneratePermissionChanges(oldFolder.Permissions, changes)
 	if err != nil {
-		return fmt.Errorf("Generating Folder Permission Changes: %w", err)
+		return fmt.Errorf("generating Folder Permission Changes: %w", err)
 	}
 
 	err = c.ShareFolder(ctx, folderID, permissionChanges)
 	if err != nil {
-		return fmt.Errorf("Sharing Folder: %w", err)
+		return fmt.Errorf("sharing Folder: %w", err)
 	}
 	return nil
 }
@@ -195,14 +201,14 @@ func GeneratePermissionChanges(oldPermissions []api.Permission, changes []ShareO
 	for i, changeA := range changes {
 		for j, changeB := range changes {
 			if i != j && changeA.AROID == changeB.AROID && changeA.ARO == changeB.ARO {
-				return nil, fmt.Errorf("Change %v and %v are Both About the same ARO %v ID: %v, there can only be once change per ARO", i, j, changeA.ARO, changeA.AROID)
+				return nil, fmt.Errorf("change %v and %v are Both About the same ARO %v ID: %v, there can only be once change per ARO", i, j, changeA.ARO, changeA.AROID)
 			}
 		}
 	}
 
 	// Get ACO and ACO ID from Existing Permissions
 	if len(oldPermissions) == 0 {
-		return nil, fmt.Errorf("There has to be atleast one Permission on a ACO")
+		return nil, fmt.Errorf("there has to be atleast one Permission on a ACO")
 	}
 	ACO := oldPermissions[0].ACO
 	ACOID := oldPermissions[0].ACOForeignKey
@@ -229,9 +235,9 @@ func GeneratePermissionChanges(oldPermissions []api.Permission, changes []ShareO
 					ACOForeignKey: ACOID,
 				})
 			} else if change.Type == -1 {
-				return nil, fmt.Errorf("Permission for %v %v Cannot be Deleted as No Matching Permission Exists", change.ARO, change.AROID)
+				return nil, fmt.Errorf("permission for %v %v Cannot be Deleted as No Matching Permission Exists", change.ARO, change.AROID)
 			} else {
-				return nil, fmt.Errorf("Unknown Permission Type: %v", change.Type)
+				return nil, fmt.Errorf("unknown Permission Type: %v", change.Type)
 			}
 		} else {
 			tmp := api.Permission{
@@ -244,14 +250,14 @@ func GeneratePermissionChanges(oldPermissions []api.Permission, changes []ShareO
 
 			if change.Type == 15 || change.Type == 7 || change.Type == 1 {
 				if oldPermission.Type == change.Type {
-					return nil, fmt.Errorf("Permission for %v %v is already Type %v", change.ARO, change.AROID, change.Type)
+					return nil, fmt.Errorf("permission for %v %v is already Type %v", change.ARO, change.AROID, change.Type)
 				}
 				tmp.Type = change.Type
 			} else if change.Type == -1 {
 				tmp.Delete = true
 				tmp.Type = oldPermission.Type
 			} else {
-				return nil, fmt.Errorf("Unknown Permission Type: %v", change.Type)
+				return nil, fmt.Errorf("unknown Permission Type: %v", change.Type)
 			}
 			permissionChanges = append(permissionChanges, tmp)
 		}

--- a/helper/totp.go
+++ b/helper/totp.go
@@ -38,7 +38,7 @@ func GenerateOTPCode(token string, when time.Time) (string, error) {
 
 	secretBytes, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(token)
 	if err != nil {
-		return "", fmt.Errorf("Decoding token string: %w", err)
+		return "", fmt.Errorf("decoding token string: %w", err)
 	}
 
 	buf := make([]byte, 8)

--- a/helper/user.go
+++ b/helper/user.go
@@ -11,7 +11,7 @@ import (
 func CreateUser(ctx context.Context, c *api.Client, role, username, firstname, lastname string) (string, error) {
 	roles, err := c.GetRoles(ctx)
 	if err != nil {
-		return "", fmt.Errorf("Get Role: %w", err)
+		return "", fmt.Errorf("get Role: %w", err)
 	}
 
 	roleID := ""
@@ -24,7 +24,7 @@ func CreateUser(ctx context.Context, c *api.Client, role, username, firstname, l
 	}
 
 	if roleID == "" {
-		return "", fmt.Errorf("Cannot Find Role: %v", role)
+		return "", fmt.Errorf("cannot Find Role: %v", role)
 	}
 
 	u, err := c.CreateUser(ctx, api.User{
@@ -36,7 +36,7 @@ func CreateUser(ctx context.Context, c *api.Client, role, username, firstname, l
 		RoleID: roleID,
 	})
 	if err != nil {
-		return "", fmt.Errorf("Creating User: %w", err)
+		return "", fmt.Errorf("creating User: %w", err)
 	}
 	return u.ID, nil
 }
@@ -45,7 +45,7 @@ func CreateUser(ctx context.Context, c *api.Client, role, username, firstname, l
 func GetUser(ctx context.Context, c *api.Client, userID string) (string, string, string, string, error) {
 	u, err := c.GetUser(ctx, userID)
 	if err != nil {
-		return "", "", "", "", fmt.Errorf("Getting User: %w", err)
+		return "", "", "", "", fmt.Errorf("getting User: %w", err)
 	}
 	return u.Role.Name, u.Username, u.Profile.FirstName, u.Profile.LastName, nil
 }
@@ -54,7 +54,7 @@ func GetUser(ctx context.Context, c *api.Client, userID string) (string, string,
 func UpdateUser(ctx context.Context, c *api.Client, userID, role, firstname, lastname string) error {
 	user, err := c.GetUser(ctx, userID)
 	if err != nil {
-		return fmt.Errorf("Getting User: %w", err)
+		return fmt.Errorf("getting User: %w", err)
 	}
 
 	new := api.User{
@@ -67,7 +67,7 @@ func UpdateUser(ctx context.Context, c *api.Client, userID, role, firstname, las
 	if role != "" {
 		roles, err := c.GetRoles(ctx)
 		if err != nil {
-			return fmt.Errorf("Get Role: %w", err)
+			return fmt.Errorf("get Role: %w", err)
 		}
 
 		roleID := ""
@@ -80,7 +80,7 @@ func UpdateUser(ctx context.Context, c *api.Client, userID, role, firstname, las
 		}
 
 		if roleID == "" {
-			return fmt.Errorf("Cannot Find Role %v", role)
+			return fmt.Errorf("cannot Find Role %v", role)
 		}
 		new.RoleID = roleID
 	}
@@ -94,7 +94,7 @@ func UpdateUser(ctx context.Context, c *api.Client, userID, role, firstname, las
 
 	_, err = c.UpdateUser(ctx, userID, new)
 	if err != nil {
-		return fmt.Errorf("Updating User: %w", err)
+		return fmt.Errorf("updating User: %w", err)
 	}
 	return nil
 }
@@ -103,7 +103,7 @@ func UpdateUser(ctx context.Context, c *api.Client, userID, role, firstname, las
 func DeleteUser(ctx context.Context, c *api.Client, userID string) error {
 	err := c.DeleteUser(ctx, userID)
 	if err != nil {
-		return fmt.Errorf("Deleting User: %w", err)
+		return fmt.Errorf("deleting User: %w", err)
 	}
 	return nil
 }

--- a/helper/util.go
+++ b/helper/util.go
@@ -12,7 +12,7 @@ func getPublicKeyByUserID(userID string, Users []api.User) (string, error) {
 			return user.GPGKey.ArmoredKey, nil
 		}
 	}
-	return "", fmt.Errorf("Cannot Find Key for user id %v", userID)
+	return "", fmt.Errorf("cannot Find Key for user id %v", userID)
 }
 
 func getMembershipByUserID(memberships []api.GroupMembership, userID string) (*api.GroupMembership, error) {
@@ -21,7 +21,7 @@ func getMembershipByUserID(memberships []api.GroupMembership, userID string) (*a
 			return &membership, nil
 		}
 	}
-	return nil, fmt.Errorf("Cannot Find Membership for user id %v", userID)
+	return nil, fmt.Errorf("cannot Find Membership for user id %v", userID)
 }
 
 func getSecretByResourceID(secrets []api.Secret, resourceID string) (*api.Secret, error) {
@@ -30,5 +30,5 @@ func getSecretByResourceID(secrets []api.Secret, resourceID string) (*api.Secret
 			return &secret, nil
 		}
 	}
-	return nil, fmt.Errorf("Cannot Find Secret for id %v", resourceID)
+	return nil, fmt.Errorf("cannot Find Secret for id %v", resourceID)
 }

--- a/helper/util.go
+++ b/helper/util.go
@@ -12,7 +12,7 @@ func getPublicKeyByUserID(userID string, Users []api.User) (string, error) {
 			return user.GPGKey.ArmoredKey, nil
 		}
 	}
-	return "", fmt.Errorf("cannot Find Key for user id %v", userID)
+	return "", fmt.Errorf("%w: %v", ErrKeyNotFound, userID)
 }
 
 func getMembershipByUserID(memberships []api.GroupMembership, userID string) (*api.GroupMembership, error) {
@@ -21,7 +21,7 @@ func getMembershipByUserID(memberships []api.GroupMembership, userID string) (*a
 			return &membership, nil
 		}
 	}
-	return nil, fmt.Errorf("cannot Find Membership for user id %v", userID)
+	return nil, fmt.Errorf("%w: %v", ErrMembershipNotFound, userID)
 }
 
 func getSecretByResourceID(secrets []api.Secret, resourceID string) (*api.Secret, error) {
@@ -30,5 +30,5 @@ func getSecretByResourceID(secrets []api.Secret, resourceID string) (*api.Secret
 			return &secret, nil
 		}
 	}
-	return nil, fmt.Errorf("cannot Find Secret for id %v", resourceID)
+	return nil, fmt.Errorf("%w: %v", ErrSecretNotFound, resourceID)
 }

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,10 +1,10 @@
-checks = ["all", "-ST1005", "-ST1000", "-ST1003", "-ST1016"]
+checks = ["all"]
 initialisms = ["ACL", "API", "ASCII", "CPU", "CSS", "DNS",
 	"EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID",
 	"IP", "JSON", "QPS", "RAM", "RPC", "SLA",
 	"SMTP", "SQL", "SSH", "TCP", "TLS", "TTL",
 	"UDP", "UI", "GID", "UID", "UUID", "URI",
 	"URL", "UTF8", "VM", "XML", "XMPP", "XSRF",
-	"XSS"]
+	"XSS", "MFA"]
 dot_import_whitelist = []
 http_status_code_whitelist = ["200", "400", "404", "500"]


### PR DESCRIPTION
Fix all staticcheck lint warnings across go-passbolt (SDK) and go-passbolt-cli (CLI). After this change, make lint passes cleanly with zero warnings.

Changes include:

Lowercase error strings to follow Go conventions (ST1005)
Add missing package doc comments (ST1000)
Fix malformed doc comments (ST1021/ST1020/ST1022/ST1023)
Rename identifiers to follow Go naming conventions (ST1003)
Replace deprecated API calls (SA1019)
Simplify boolean comparisons (S1002)
Fix potential nil pointer dereference in tests (SA5011)
Remove unused code and assignments (U1000, SA4006)
Remove redundant break statements (S1023)

Breaking changes:

Renamed types and functions to follow Go conventions (Json → JSON, Id → ID, Http → HTTP):

- ResourceJsonOutput → ResourceJSONOutput
- FolderJsonOutput → FolderJSONOutput
- GroupJsonOutput → GroupJSONOutput
- UserJsonOutput → UserJSONOutput
- PermissionJsonOutput → PermissionJSONOutput
- GetHttpClient() → GetHTTPClient()
- Various internal jsonId → jsonID, resourceId → resourceID renames