### PR TITLE
Feature/PB 49956 Go add golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,59 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - gocritic
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unconvert
+    - unused
+  settings:
+    gocritic:
+      disabled-checks:
+        - captLocal
+        - commentFormatting
+    misspell:
+      locale: US
+  exclusions:
+    rules:
+      # Exclude errcheck and gosec from test files
+      - path: _test\.go
+        linters:
+          - errcheck
+          - gosec
+      # G101: false positive on constants with "password"/"secret" in name
+      - text: "G101:"
+        linters:
+          - gosec
+      # G402: intentional InsecureSkipVerify for user-configured TLS skip
+      - text: "G402:"
+        linters:
+          - gosec
+      # G505: crypto/sha1 needed for TOTP (RFC 6238/4226)
+      - text: "G505:"
+        linters:
+          - gosec
+      # G704: false positive SSRF on internal HTTP client Do() wrapper
+      - text: "G704:"
+        linters:
+          - gosec
+      # G117: false positive on marshaling password struct fields sent to Passbolt API
+      - text: "G117:"
+        linters:
+          - gosec
+      # resp.Body.Close() in defer — standard Go pattern, error is non-actionable
+      - text: "resp.Body.Close"
+        linters:
+          - errcheck
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/api/api.go
+++ b/api/api.go
@@ -75,9 +75,10 @@ start:
 		}
 	}
 
-	if res.Header.Status == "success" {
+	switch res.Header.Status {
+	case "success":
 		return r, &res, nil
-	} else if res.Header.Status == "error" {
+	case "error":
 		if res.Header.Code == 403 && strings.HasSuffix(res.Header.URL, "/mfa/verify/error.json") {
 			if !firstTime {
 				// if we are here this probably means that the MFA callback is broken, to prevent a infinite loop lets error here
@@ -96,7 +97,7 @@ start:
 			}
 		}
 		return r, &res, &APIError{StatusCode: res.Header.Code, Message: res.Header.Message, Body: string(res.Body)}
-	} else {
+	default:
 		return r, &res, &APIError{StatusCode: res.Header.Code, Message: res.Header.Message, Body: string(res.Body)}
 	}
 }

--- a/api/auth.go
+++ b/api/auth.go
@@ -47,7 +47,7 @@ func (c *Client) Login(ctx context.Context) error {
 
 	res, _, err := c.DoCustomRequestAndReturnRawResponse(ctx, "POST", "/auth/login.json", "v2", data, nil)
 	var apiErr *APIError
-	if err != nil && !(errors.As(err, &apiErr) && apiErr.Message == "The authentication failed.") {
+	if err != nil && (!errors.As(err, &apiErr) || apiErr.Message != "The authentication failed.") {
 		return fmt.Errorf("doing Stage 1 Request: %w", err)
 	}
 
@@ -77,7 +77,7 @@ func (c *Client) Login(ctx context.Context) error {
 		return fmt.Errorf("checking Auth Token Format: %w", err)
 	}
 
-	data.Auth.Token = string(authToken)
+	data.Auth.Token = authToken
 
 	res, _, err = c.DoCustomRequestAndReturnRawResponse(ctx, "POST", "/auth/login.json", "v2", data, nil)
 	if err != nil {
@@ -87,13 +87,14 @@ func (c *Client) Login(ctx context.Context) error {
 	c.log("Got Cookies: %+v", res.Cookies())
 
 	for _, cookie := range res.Cookies() {
-		if cookie.Name == "passbolt_session" {
+		switch cookie.Name {
+		case "passbolt_session":
 			c.sessionToken = *cookie
+		case "CAKEPHP":
 			// Session Cookie in older Passbolt Versions
-		} else if cookie.Name == "CAKEPHP" {
 			c.sessionToken = *cookie
+		case "PHPSESSID":
 			// Session Cookie in Cloud version?
-		} else if cookie.Name == "PHPSESSID" {
 			c.sessionToken = *cookie
 		}
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -63,7 +63,7 @@ type Client struct {
 	// MetadataKeyUpdatedCallback is Called by the Client when the Metadatakey has changed
 	// trusted shows if this key has been signed and thus been trusted by another client of this user
 	// the consumer should prompt the user about the keychange and save the new fingerprint (may be skipped if it is trusted).
-	// If no error is returned then the new key will be accepted and its fingerpint set in the client
+	// If no error is returned then the new key will be accepted and its fingerprint set in the client
 	MetadataKeyUpdatedCallback func(ctx context.Context, trusted bool, fingerprint string, signTime time.Time) error
 
 	// used for solving MFA challenges. You can block this to for example wait for user input.
@@ -78,7 +78,8 @@ type Client struct {
 	Debug bool
 
 	// Cache for resource types (rarely change)
-	resourceTypesCache []ResourceType
+	resourceTypesCache   []ResourceType
+	resourceTypesCacheMu sync.RWMutex
 
 	// Cache for metadata keys (includes decrypted private keys)
 	metadataKeysCache []MetadataKey
@@ -151,7 +152,7 @@ func (c *Client) newRequest(method, url string, body interface{}) (*http.Request
 		buf = new(bytes.Buffer)
 		err := json.NewEncoder(buf).Encode(body)
 		if err != nil {
-			return nil, fmt.Errorf("jSON Encoding Request: %w", err)
+			return nil, fmt.Errorf("JSON encoding Request: %w", err)
 		}
 	}
 
@@ -194,13 +195,11 @@ func (c *Client) do(ctx context.Context, req *http.Request, v *APIResponse) (*ht
 			return nil, fmt.Errorf("request: %w", err)
 		}
 	}
-	defer func() {
-		resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return resp, fmt.Errorf("error Reading Resopnse Body: %w", err)
+		return resp, fmt.Errorf("error reading Response Body: %w", err)
 	}
 
 	c.log("Raw Response: %v", string(bodyBytes))
@@ -325,11 +324,16 @@ func (c *Client) ClearCache() {
 
 // ClearResourceTypesCache clears the resource types cache
 func (c *Client) ClearResourceTypesCache() {
+	c.resourceTypesCacheMu.Lock()
 	c.resourceTypesCache = nil
+	c.resourceTypesCacheMu.Unlock()
 }
 
 // ClearMetadataKeysCache clears the metadata keys cache with secure memory zeroing
 func (c *Client) ClearMetadataKeysCache() {
+	c.cryptoMu.Lock()
+	defer c.cryptoMu.Unlock()
+
 	c.metadataKeysCache = nil
 
 	// Securely zero all cached decrypted keys before clearing
@@ -386,28 +390,40 @@ func cloneSessionKey(sk *crypto.SessionKey) *crypto.SessionKey {
 
 // GetResourceTypesCached returns cached resource types, fetching from API if cache is empty
 func (c *Client) GetResourceTypesCached(ctx context.Context) ([]ResourceType, error) {
+	c.resourceTypesCacheMu.RLock()
 	if c.resourceTypesCache != nil {
-		return c.resourceTypesCache, nil
+		result := c.resourceTypesCache
+		c.resourceTypesCacheMu.RUnlock()
+		return result, nil
 	}
+	c.resourceTypesCacheMu.RUnlock()
 
 	types, err := c.GetResourceTypes(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
+	c.resourceTypesCacheMu.Lock()
 	c.resourceTypesCache = types
+	c.resourceTypesCacheMu.Unlock()
 	return types, nil
 }
 
 // GetResourceTypeCached returns a cached resource type by ID, fetching from API if not in cache
 func (c *Client) GetResourceTypeCached(ctx context.Context, typeID string) (*ResourceType, error) {
 	// First check the cache
+	c.resourceTypesCacheMu.RLock()
 	if c.resourceTypesCache != nil {
 		for i := range c.resourceTypesCache {
 			if c.resourceTypesCache[i].ID == typeID {
-				return &c.resourceTypesCache[i], nil
+				result := &c.resourceTypesCache[i]
+				c.resourceTypesCacheMu.RUnlock()
+				return result, nil
 			}
 		}
+		c.resourceTypesCacheMu.RUnlock()
+	} else {
+		c.resourceTypesCacheMu.RUnlock()
 	}
 
 	// Populate cache and search again
@@ -443,9 +459,13 @@ func (c *Client) GetResourceTypeBySlugCached(ctx context.Context, slug string) (
 
 // GetMetadataKeysCached returns cached metadata keys, fetching from API if cache is empty
 func (c *Client) GetMetadataKeysCached(ctx context.Context) ([]MetadataKey, error) {
+	c.cryptoMu.RLock()
 	if c.metadataKeysCache != nil {
-		return c.metadataKeysCache, nil
+		result := c.metadataKeysCache
+		c.cryptoMu.RUnlock()
+		return result, nil
 	}
+	c.cryptoMu.RUnlock()
 
 	keys, err := c.GetMetadataKeys(ctx, &GetMetadataKeysOptions{
 		ContainMetadataPrivateKeys: true,
@@ -454,7 +474,9 @@ func (c *Client) GetMetadataKeysCached(ctx context.Context) ([]MetadataKey, erro
 		return nil, err
 	}
 
+	c.cryptoMu.Lock()
 	c.metadataKeysCache = keys
+	c.cryptoMu.Unlock()
 	return keys, nil
 }
 
@@ -533,7 +555,9 @@ func (c *Client) GetDecryptedMetadataKeyCached(ctx context.Context, id string) (
 	}
 
 	// Cache the decrypted key
+	c.cryptoMu.Lock()
 	c.decryptedMetadataKeysCache[id] = metadataPrivateKeyObj
+	c.cryptoMu.Unlock()
 
 	// Return a copy so caller cannot affect cached key
 	keyCopy, err := metadataPrivateKeyObj.Copy()
@@ -577,7 +601,7 @@ func (c *Client) PreFetchCaches(ctx context.Context) (sessionCount, metadataKeyC
 	if err != nil {
 		// Log but don't fail - session key caching is optional optimization
 		c.log("Warning: Failed to fetch session keys: %v", err)
-		err = nil // Clear error to continue
+		err = nil //nolint:ineffassign // intentional: clear error to continue
 	}
 
 	// Then, pre-decrypt all metadata private keys
@@ -585,7 +609,7 @@ func (c *Client) PreFetchCaches(ctx context.Context) (sessionCount, metadataKeyC
 	if err != nil {
 		// Log but don't fail - this is also optional optimization
 		c.log("Warning: Failed to pre-decrypt metadata keys: %v", err)
-		err = nil
+		err = nil //nolint:ineffassign // intentional: clear error to continue
 	}
 
 	return sessionCount, metadataKeyCount, nil

--- a/api/metadatakey.go
+++ b/api/metadatakey.go
@@ -167,7 +167,7 @@ func (c *Client) GetMetadataKey(ctx context.Context, personal bool) (string, Met
 	// Verify the key
 	if c.GetTrustedMetadatakeyFingerprint() == nil || metadataPrivateKeyObj.GetFingerprint() != *c.GetTrustedMetadatakeyFingerprint() {
 
-		if c.trustedMetadataKeySigntime != nil && !data.Signed.Time.After(*c.trustedMetadataKeySigntime) {
+		if c.trustedMetadataKeySigntime != nil && !data.Signed.After(*c.trustedMetadataKeySigntime) {
 			return "", "", nil, fmt.Errorf("new Metadata Key is older than the currently trusted one: %w", err)
 		}
 

--- a/api/time.go
+++ b/api/time.go
@@ -25,5 +25,5 @@ func (t *Time) UnmarshalJSON(buf []byte) error {
 
 // MarshalJSON Marshals Passbolt *Time
 func (t Time) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + t.Time.Format(time.RFC3339) + `"`), nil
+	return []byte(`"` + t.Format(time.RFC3339) + `"`), nil
 }

--- a/helper/metadata.go
+++ b/helper/metadata.go
@@ -24,7 +24,7 @@ func GetResourceMetadata(ctx context.Context, c *api.Client, resource *api.Resou
 	if cachedSessionKey := c.GetSessionKeyByResourceID(resource.ID); cachedSessionKey != nil {
 		decMetadata, err := c.DecryptMetadataWithResourceID(resource.ID, "", nil, resource.Metadata)
 		if err == nil {
-			err = validateMetadata(rType, string(decMetadata))
+			err = validateMetadata(rType, decMetadata)
 			if err != nil {
 				return "", fmt.Errorf("validate Metadata: %w", err)
 			}
@@ -61,7 +61,7 @@ func GetResourceMetadata(ctx context.Context, c *api.Client, resource *api.Resou
 		return "", fmt.Errorf("decrypt Metadata: %w", err)
 	}
 
-	err = validateMetadata(rType, string(decMetadata))
+	err = validateMetadata(rType, decMetadata)
 	if err != nil {
 		return "", fmt.Errorf("validate Metadata: %w", err)
 	}

--- a/helper/resource_create.go
+++ b/helper/resource_create.go
@@ -56,7 +56,7 @@ func CreateResourceV5(ctx context.Context, c *api.Client, folderParentID, name, 
 
 	metaData, err := json.Marshal(&meta)
 	if err != nil {
-		return "", fmt.Errorf("marshalling metadata: %w", err)
+		return "", fmt.Errorf("marshaling metadata: %w", err)
 	}
 
 	err = validateMetadata(rType, string(metaData))
@@ -86,7 +86,7 @@ func CreateResourceV5(ctx context.Context, c *api.Client, folderParentID, name, 
 
 	secretData, err := json.Marshal(&secret)
 	if err != nil {
-		return "", fmt.Errorf("marshalling Secret Data: %w", err)
+		return "", fmt.Errorf("marshaling Secret Data: %w", err)
 	}
 
 	err = validateSecretData(rType, string(secretData))
@@ -147,7 +147,7 @@ func CreateResourceV4(ctx context.Context, c *api.Client, folderParentID, name, 
 	}
 	secretData, err := json.Marshal(&tmp)
 	if err != nil {
-		return "", fmt.Errorf("marshalling Secret Data: %w", err)
+		return "", fmt.Errorf("marshaling Secret Data: %w", err)
 	}
 
 	err = validateSecretData(rType, string(secretData))

--- a/helper/resource_update.go
+++ b/helper/resource_update.go
@@ -49,7 +49,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 		var metadataMap map[string]any
 		err = json.Unmarshal([]byte(orgMetadata), &metadataMap)
 		if err != nil {
-			return fmt.Errorf("marshalling metadata: %w", err)
+			return fmt.Errorf("marshaling metadata: %w", err)
 		}
 
 		var newMetadata []byte
@@ -104,7 +104,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 		newMetadata, err = json.Marshal(&metadataMap)
 		if err != nil {
-			return fmt.Errorf("marshalling metadata: %w", err)
+			return fmt.Errorf("marshaling metadata: %w", err)
 		}
 
 		// Validate Metadata
@@ -165,7 +165,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 			}
 			res, err := json.Marshal(&tmp)
 			if err != nil {
-				return fmt.Errorf("marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshaling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		case "v5-password-string":
@@ -204,7 +204,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 			res, err := json.Marshal(&oldSecret)
 			if err != nil {
-				return fmt.Errorf("marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshaling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		case "v5-totp-standalone":
@@ -225,7 +225,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 			res, err := json.Marshal(&oldSecret)
 			if err != nil {
-				return fmt.Errorf("marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshaling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		default:
@@ -294,7 +294,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 			}
 			res, err := json.Marshal(&tmp)
 			if err != nil {
-				return fmt.Errorf("marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshaling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		case "password-description-totp":
@@ -320,7 +320,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 			res, err := json.Marshal(&oldSecret)
 			if err != nil {
-				return fmt.Errorf("marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshaling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		case "totp":
@@ -341,7 +341,7 @@ func UpdateResource(ctx context.Context, c *api.Client, resourceID, name, userna
 
 			res, err := json.Marshal(&oldSecret)
 			if err != nil {
-				return fmt.Errorf("marshalling Secret Data: %w", err)
+				return fmt.Errorf("marshaling Secret Data: %w", err)
 			}
 			secretData = string(res)
 		default:

--- a/helper/share.go
+++ b/helper/share.go
@@ -96,7 +96,7 @@ func ShareResource(ctx context.Context, c *api.Client, resourceID string, change
 		resource.MetadataKeyID = metadataKeyID
 		resource.MetadataKeyType = metadataKeyType
 
-		encMetadata, err := c.EncryptMessageWithKey(publicMetadataKey, string(metadata))
+		encMetadata, err := c.EncryptMessageWithKey(publicMetadataKey, metadata)
 		if err != nil {
 			return fmt.Errorf("encrypt Metadata: %w", err)
 		}
@@ -225,7 +225,8 @@ func GeneratePermissionChanges(oldPermissions []api.Permission, changes []ShareO
 		}
 		// Check Whether Matching Permission Already Exists and needs to be adjusted or is a new one can be created
 		if oldPermission == nil {
-			if change.Type == 15 || change.Type == 7 || change.Type == 1 {
+			switch change.Type {
+			case 15, 7, 1:
 				permissionChanges = append(permissionChanges, api.Permission{
 					IsNew:         true,
 					Type:          change.Type,
@@ -234,9 +235,9 @@ func GeneratePermissionChanges(oldPermissions []api.Permission, changes []ShareO
 					ACO:           ACO,
 					ACOForeignKey: ACOID,
 				})
-			} else if change.Type == -1 {
+			case -1:
 				return nil, fmt.Errorf("permission for %v %v Cannot be Deleted as No Matching Permission Exists", change.ARO, change.AROID)
-			} else {
+			default:
 				return nil, fmt.Errorf("unknown Permission Type: %v", change.Type)
 			}
 		} else {
@@ -248,15 +249,16 @@ func GeneratePermissionChanges(oldPermissions []api.Permission, changes []ShareO
 				ACOForeignKey: ACOID,
 			}
 
-			if change.Type == 15 || change.Type == 7 || change.Type == 1 {
+			switch change.Type {
+			case 15, 7, 1:
 				if oldPermission.Type == change.Type {
 					return nil, fmt.Errorf("permission for %v %v is already Type %v", change.ARO, change.AROID, change.Type)
 				}
 				tmp.Type = change.Type
-			} else if change.Type == -1 {
+			case -1:
 				tmp.Delete = true
 				tmp.Type = oldPermission.Type
-			} else {
+			default:
 				return nil, fmt.Errorf("unknown Permission Type: %v", change.Type)
 			}
 			permissionChanges = append(permissionChanges, tmp)

--- a/helper/totp.go
+++ b/helper/totp.go
@@ -28,7 +28,7 @@ func GenerateOTPCode(token string, when time.Time) (string, error) {
 	// Remove spaces, some providers are giving us in a readable format
 	// so they add spaces in there. If it's not removed while pasting in,
 	// remove it now.
-	token = strings.Replace(token, " ", "", -1)
+	token = strings.ReplaceAll(token, " ", "")
 
 	// It should be uppercase always
 	token = strings.ToUpper(token)
@@ -55,7 +55,7 @@ func GenerateOTPCode(token string, when time.Time) (string, error) {
 		((int(sum[offset+2] & mask3)) << shift8) |
 		(int(sum[offset+3]) & mask3))
 
-	modulo := int32(value % int64(math.Pow10(codeLength)))
+	modulo := value % int64(math.Pow10(codeLength))
 
 	format := fmt.Sprintf("%%0%dd", codeLength)
 


### PR DESCRIPTION
The project only uses staticcheck for linting. `golangci-lint` provides a comprehensive suite of linters (including staticcheck) with better performance and more extensive checks. Without it, code quality issues like inefficient assignments, unused code, and potential bugs may go undetected.

Signed-off-by: Cédric HERZOG <cedric.herzog@passbolt.com>