### PR TITLE
Feature/PB 50035 Go Add linting to ci

### DIFF
--- a/.github/workflows/.go.yml
+++ b/.github/workflows/.go.yml
@@ -7,13 +7,25 @@ on:
     branches: [main, v5]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.4
+
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: '1.25'
       - name: "Setup Passbolt"
         run: |
           git clone https://github.com/passbolt/passbolt_docker.git ../passbolt_docker


### PR DESCRIPTION
Linting is not currently part of the CI pipeline (`.github/workflows/` ). This means code quality violations can be merged without detection, and contributors may not know their code has issues until after PR submission.

Signed-off-by: Cédric HERZOG <cedric.herzog@passbolt.com>