### PR TITLE
Feature/PB 50036 Go Create pre commit hooks

### DIFF
--- a/.github/workflows/.go.yml
+++ b/.github/workflows/.go.yml
@@ -7,13 +7,25 @@ on:
     branches: [main, v5]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.4
+
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: '1.25'
       - name: "Setup Passbolt"
         run: |
           git clone https://github.com/passbolt/passbolt_docker.git ../passbolt_docker

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+pre-commit:
+  parallel: true
+  commands:
+    fmt-check:
+      glob: "*.go"
+      run: gofmt -l {staged_files} | grep . && echo "Run 'go fmt' to fix" && exit 1 || true
+    golangci-lint:
+      glob: "*.go"
+      run: golangci-lint run --new-from-rev=HEAD ./...


### PR DESCRIPTION
Developers may commit code without running linters or formatters locally, leading to CI failures and back-and-forth in PR reviews. Pre-commit hooks can catch these issues before they're committed.

Signed-off-by: Cédric HERZOG <cedric.herzog@passbolt.com>